### PR TITLE
Create DB from schema on start if config option is set

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -8,7 +8,7 @@
     "behindProxy": true,
     "db": "./databases/sponsorTimes.db",
     "privateDB": "./databases/private.db",
-    "createDatabaseIfNotExist": true, //depends on mode='development' //This will run on startup every time - so ensure "create table if not exists" is used in the schema
+    "createDatabaseIfNotExist": true, //This will run on startup every time (unless readOnly is true) - so ensure "create table if not exists" is used in the schema
     "dbSchema": "./databases/_sponsorTimes.db.sql",
     "privateDBSchema": "./databases/_private.db.sql",
     "mode": "development",

--- a/config.json.example
+++ b/config.json.example
@@ -8,6 +8,9 @@
     "behindProxy": true,
     "db": "./databases/sponsorTimes.db",
     "privateDB": "./databases/private.db",
+    "createDatabaseIfNotExist": true, //depends on mode='development' //This will run on startup every time - so ensure "create table if not exists" is used in the schema
+    "dbSchema": "./databases/_sponsorTimes.db.sql",
+    "privateDBSchema": "./databases/_private.db.sql",
     "mode": "development",
     "readOnly": false
 }

--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,6 @@
 {
+    // Remove all comments from the config when using it!
+
     "port": 80,
     "globalSalt": "[global salt (pepper) that is added to every ip before hashing to make it even harder for someone to decode the ip]",
     "adminUserID": "[the hashed id of the user who can perform admin actions]",

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var db = new Sqlite3(config.db, options);
 //where the more sensitive data such as IP addresses are stored
 var privateDB = new Sqlite3(config.privateDB, options);
 
-if (config.createDatabaseIfNotExist && (config.mode === "development")) {
+if (config.createDatabaseIfNotExist && !config.readOnly) {
     db.exec(fs.readFileSync(config.dbSchema).toString());
     privateDB.exec(fs.readFileSync(config.privateDBSchema).toString());
 }

--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@ var db = new Sqlite3(config.db, options);
 //where the more sensitive data such as IP addresses are stored
 var privateDB = new Sqlite3(config.privateDB, options);
 
+if (config.createDatabaseIfNotExist && (config.mode === "development")) {
+    db.exec(fs.readFileSync(config.dbSchema).toString());
+    privateDB.exec(fs.readFileSync(config.privateDBSchema).toString());
+}
+
 // Create an HTTP service.
 http.createServer(app).listen(config.port);
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ YouTubeAPI.authenticate({
 var Sqlite3 = require('better-sqlite3');
 
 let options = {
-    readonly: config.readOnly
+    readonly: config.readOnly,
+    fileMustExist: !config.createDatabaseIfNotExist
 };
 
 //load database
@@ -30,8 +31,8 @@ var db = new Sqlite3(config.db, options);
 var privateDB = new Sqlite3(config.privateDB, options);
 
 if (config.createDatabaseIfNotExist && !config.readOnly) {
-    db.exec(fs.readFileSync(config.dbSchema).toString());
-    privateDB.exec(fs.readFileSync(config.privateDBSchema).toString());
+    if (fs.existsSync(config.dbSchema)) db.exec(fs.readFileSync(config.dbSchema).toString());
+    if (fs.existsSync(config.privateDBSchema)) privateDB.exec(fs.readFileSync(config.privateDBSchema).toString());
 }
 
 // Create an HTTP service.


### PR DESCRIPTION
Implementing https://github.com/ajayyy/SponsorBlockServer/issues/46

If the createDatabaseIfNotExist value is true and the mode is development, initialise the db from the schema file defined in the config file.