### PR TITLE
Bug Fix: Don't allow Infinity to be passed into the database as a sponsor time.

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,12 @@ async function submitSponsorTimes(req, res) {
         return;
     }
 
+    if (startTime === Infinity || endTime === Infinity) {
+        //invalid request
+        res.sendStatus(400);
+        return;
+    }
+
     if (startTime > endTime) {
         //time can't go backwards
         res.sendStatus(400);


### PR DESCRIPTION
Infinity is a valid number, and when passed either as `endTime=Infinity` or something like `endTime=99e9999` it ends up being stored in the database:

```
test|0.0|Inf|0|[too much data]|[too much data]|1584497921519|0|0
```

This results in a null value being returned as a sponsor time:

```
$ curl 'http://localhost:8080/api/getVideoSponsorTimes?videoID=test' | jq
{
  "sponsorTimes": [
    [
      0,
      null
    ]
  ],
  "UUIDs": [
    "[too much data]"
  ]
}
```