### PR TITLE
Unified ignore expression for segments

### DIFF
--- a/src/routes/getDaysSavedFormatted.js
+++ b/src/routes/getDaysSavedFormatted.js
@@ -1,7 +1,8 @@
 var db = require('../databases/databases.js').db;
 
 module.exports = function getDaysSavedFormatted (req, res) {
-  let row = db.prepare('get', "SELECT SUM((endTime - startTime) / 60 / 60 / 24 * views) as daysSaved from sponsorTimes where shadowHidden != 1", []);
+  // One day has 86400 seconds
+  let row = db.prepare('get', "SELECT SUM((endTime - startTime) / 86400 * views) as daysSaved FROM sponsorTimes WHERE votes > -2 AND shadowHidden != 1", []);
       
   if (row !== undefined) {
       //send this result

--- a/src/routes/getSavedTimeForUser.js
+++ b/src/routes/getSavedTimeForUser.js
@@ -14,7 +14,7 @@ module.exports = function getSavedTimeForUser (req, res) {
   userID = getHash(userID);
 
   try {
-      let row = db.prepare("get", "SELECT SUM((endTime - startTime) / 60 * views) as minutesSaved FROM sponsorTimes WHERE userID = ? AND votes > -1 AND shadowHidden != 1 ", [userID]);
+      let row = db.prepare("get", "SELECT SUM((endTime - startTime) / 60 * views) as minutesSaved FROM sponsorTimes WHERE userID = ? AND votes > -2 AND shadowHidden != 1", [userID]);
 
       if (row.minutesSaved != null) {
           res.send({

--- a/src/routes/getSkipSegments.js
+++ b/src/routes/getSkipSegments.js
@@ -21,10 +21,10 @@ function getWeightedRandomChoice(choices, amountOfChoices) {
   //assign a weight to each choice
   let totalWeight = 0;
   choices = choices.map(choice => {
-    // The initial value for votes is 0 so we have to add 1 because 
-    // everything below will be ignored
+    // The initial value for votes is 0 so we have to add 2 because 
+    // everything below (-1) will be ignored
     // https://www.desmos.com/calculator/c1duhfrmts
-    const weight = Math.exp((choice.votes + 1), 0.85);
+    const weight = Math.exp((choice.votes + 2), 0.85);
     totalWeight += weight;
 
     return { ...choice, weight };

--- a/src/routes/getSkipSegments.js
+++ b/src/routes/getSkipSegments.js
@@ -21,10 +21,10 @@ function getWeightedRandomChoice(choices, amountOfChoices) {
   //assign a weight to each choice
   let totalWeight = 0;
   choices = choices.map(choice => {
-    //The 3 makes -2 the minimum votes before being ignored completely
-    //https://www.desmos.com/calculator/c1duhfrmts
-    //this can be changed if this system increases in popularity.
-    const weight = Math.exp((choice.votes + 3), 0.85);
+    // The initial value for votes is 0 so we have to add 1 because 
+    // everything below will be ignored
+    // https://www.desmos.com/calculator/c1duhfrmts
+    const weight = Math.exp((choice.votes + 1), 0.85);
     totalWeight += weight;
 
     return { ...choice, weight };

--- a/src/routes/getTopUsers.js
+++ b/src/routes/getTopUsers.js
@@ -46,7 +46,7 @@ module.exports = function getTopUsers (req, res) {
                   additionalFields +
                   "IFNULL(userNames.userName, sponsorTimes.userID) as userName FROM sponsorTimes LEFT JOIN userNames ON sponsorTimes.userID=userNames.userID " +
                   "LEFT JOIN privateDB.shadowBannedUsers ON sponsorTimes.userID=privateDB.shadowBannedUsers.userID " +
-                  "WHERE sponsorTimes.votes > -1 AND sponsorTimes.shadowHidden != 1 AND privateDB.shadowBannedUsers.userID IS NULL " +
+                  "WHERE sponsorTimes.votes > -2 AND sponsorTimes.shadowHidden != 1 AND privateDB.shadowBannedUsers.userID IS NULL " +
                   "GROUP BY IFNULL(userName, sponsorTimes.userID) HAVING userVotes > 20 " +
                   "ORDER BY " + sortBy + " DESC LIMIT 100", []);
   

--- a/src/routes/getTotalStats.js
+++ b/src/routes/getTotalStats.js
@@ -13,7 +13,7 @@ let lastUserCountCheck = 0;
 
 module.exports = function getTotalStats (req, res) {
     let row = db.prepare('get', "SELECT COUNT(DISTINCT userID) as userCount, COUNT(*) as totalSubmissions, " +
-              "SUM(views) as viewCount, SUM((endTime - startTime) / 60 * views) as minutesSaved FROM sponsorTimes WHERE shadowHidden != 1 AND votes >= 0", []);
+              "SUM(views) as viewCount, SUM((endTime - startTime) / 60 * views) as minutesSaved FROM sponsorTimes WHERE shadowHidden != 1 AND votes > -2", []);
 
     if (row !== undefined) {
         let extensionUsers = chromeUsersCache + firefoxUsersCache;

--- a/src/routes/getViewsForUser.js
+++ b/src/routes/getViewsForUser.js
@@ -14,9 +14,7 @@ module.exports = function getViewsForUser(req, res) {
   userID = getHash(userID);
 
   try {
-      let row = db.prepare('get', "SELECT SUM(views) as viewCount FROM sponsorTimes WHERE userID = ?", [userID]);
-
-      //increase the view count by one
+      let row = db.prepare('get', "SELECT SUM(views) as viewCount FROM sponsorTimes WHERE userID = ? AND votes > -2 AND shadowHidden != 1", [userID]);
       if (row.viewCount != null) {
           res.send({
               viewCount: row.viewCount


### PR DESCRIPTION
Some SQL queries checked for `votes > -1`, others `votes >= 0` and in some they where missing.
We are filtering segments with votes below -1 out so we have to add 2 to the votes to have a minimum value of 1 for Math.exp in getSkipSegments.js