### PR TITLE
Improve missing fields checks (POST skipSegment)

### DIFF
--- a/src/routes/postSkipSegments.js
+++ b/src/routes/postSkipSegments.js
@@ -257,11 +257,22 @@ module.exports = async function postSkipSegments(req, res) {
         }];
     }
 
-    //check if all correct inputs are here and the length is 1 second or more
-    if (videoID == undefined || userID == undefined || segments == undefined || segments.length < 1) {
-        //invalid request
-        res.status(400).send("Parameters are not valid");
-        return;
+    const invalidFields = [];
+    if (typeof videoID !== 'string') {
+      invalidFields.push('videoID');
+    }
+    if (typeof userID !== 'string') {
+      invalidFields.push('userID');
+    }
+    if (!Array.isArray(segments) || segments.length < 1) {
+      invalidFields.push('segments');
+    }
+
+    if (invalidFields.length !== 0) {
+      // invalid request
+      const fields = invalidFields.reduce((p, c, i) => p + (i !== 0 ? ', ' : '') + c, '');
+      res.status(400).send(`No valid ${fields} field(s) provided`);
+      return;
     }
 
     //hash the userID


### PR DESCRIPTION
# Motivation
I don't know why but I got an error originated because a userID value in the add on's storage was missing. I only found out about the reason because I did some debugging which I'm sure not everybody (esp. a non-developer) knows how to do. Obviously the request failed but the error message was very un-informative.

I hope this PR paves the way for more/more useful bug reports. Because things will fail.

# Changes
This PR changes the message sent in case of invalid requests from `Parameters are not valid` to a message containing the missing values.
It also adds some type-checks.
