### PR TITLE
Return new created segments on success

### DIFF
--- a/src/routes/postSkipSegments.ts
+++ b/src/routes/postSkipSegments.ts
@@ -391,6 +391,7 @@ export async function postSkipSegments(req: Request, res: Response) {
     }
     // Will be filled when submitting
     const UUIDs = [];
+    const newSegments = [];
 
     try {
         //get current time
@@ -511,6 +512,11 @@ export async function postSkipSegments(req: Request, res: Response) {
             }
 
             UUIDs.push(UUID);
+            newSegments.push({
+                UUID: UUID,
+                category: segmentInfo.category,
+                segment: segmentInfo.segment,
+            });
         }
     } catch (err) {
         Logger.error(err);
@@ -520,7 +526,7 @@ export async function postSkipSegments(req: Request, res: Response) {
         return;
     }
 
-    res.sendStatus(200);
+    res.json(newSegments);
 
     for (let i = 0; i < segments.length; i++) {
         sendWebhooks(userID, videoID, UUIDs[i], segments[i]);


### PR DESCRIPTION
/api/skipSegments will return all new created segments with the generated UUIDs so clients can work with them like downvoting to remove.