### PR TITLE
add delete to CORS for /api/lockCategories

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -143,7 +143,7 @@ http {
             ### CORS
             if ($request_method = 'OPTIONS') {
                 add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE';
                 #
                 # Custom headers and headers various browsers *should* be OK with but aren't
                 #
@@ -158,13 +158,19 @@ http {
              }
              if ($request_method = 'POST') {
                 add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE';
                 add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
                 add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
              }
              if ($request_method = 'GET') {
                 add_header 'Access-Control-Allow-Origin' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE';
+                add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+                add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+             }
+             if ($request_method = 'DELETE') {
+                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE';
                 add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
                 add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
              }


### PR DESCRIPTION
CORS does not allow method `DELETE` which is required for removing category locks through `/api/lockCategories` 

[API Link](https://github.com/ajayyy/SponsorBlock/wiki/API-Docs#delete-apilockcategories-apinosegments-deprecated)

This can be tested by attempting to unlock a video from SponsorBlockControl