### PR TITLE
Fix Test Suite

### DIFF
--- a/test/cases/getSkipSegments.ts
+++ b/test/cases/getSkipSegments.ts
@@ -13,7 +13,7 @@ describe('getSkipSegments', () => {
         await db.prepare("run", startOfQuery + "('test3', 1, 11, 2, 0, '1-uuid-4', 'testman', 0, 50, 'sponsor', 'YouTube', 200, 0, 0, '" + getHash('test3', 1) + "')");
         await db.prepare("run", startOfQuery + "('test3', 7, 22, -3, 0, '1-uuid-5', 'testman', 0, 50, 'sponsor', 'YouTube', 300, 0, 0, '" + getHash('test3', 1) + "')");
         await db.prepare("run", startOfQuery + "('multiple', 1, 11, 2, 0, '1-uuid-6', 'testman', 0, 50, 'intro', 'YouTube', 400, 0, 0, '" + getHash('multiple', 1) + "')");
-        await db.prepare("run", startOfQuery + "('multiple', 20, 33, 2, 0, '1-uuid-7', 'testman', 0, 50, 'intro', 'YouTube', 500, 0, 0, '" + getHash('multiple', 1) + "')");
+        await db.prepare("run", startOfQuery + "('multiple', 20, 33, 2, 0, '1-uuid-7', 'testman', 0, 50, 'intro', 'YouTube', 400, 0, 0, '" + getHash('multiple', 1) + "')");
         await db.prepare("run", startOfQuery + "('locked', 20, 33, 2, 1, '1-uuid-locked-8', 'testman', 0, 50, 'intro', 'YouTube', 230, 0, 0, '" + getHash('locked', 1) + "')");
         await db.prepare("run", startOfQuery + "('locked', 20, 34, 100000, 0, '1-uuid-9', 'testman', 0, 50, 'intro', 'YouTube', 190, 0, 0, '" + getHash('locked', 1) + "')");
         await db.prepare("run", startOfQuery + "('onlyHiddenSegments', 20, 34, 100000, 0, 'onlyHiddenSegments', 'testman', 0, 50, 'sponsor', 'YouTube', 190, 1, 0, '" + getHash('onlyHiddenSegments', 1) + "')");
@@ -107,18 +107,11 @@ describe('getSkipSegments', () => {
         .catch(err => ("Couldn't call endpoint"));
     });
 
-    it('Should be empty if all submissions are hidden', (done: Done) => {
+    it('Should return 404 if all submissions are hidden', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=onlyHiddenSegments")
-        .then(async res => {
-            if (res.status !== 200) done("Status code was: " + res.status);
-            else {
-                const data = await res.json();
-                if (data.length === 0) {
-                    done();
-                } else {
-                    done("Received incorrect body: " + (await res.text()));
-                }
-            }
+        .then(res => {
+            if (res.status !== 404) done("non 404 respone code: " + res.status);
+            else done(); // pass
         })
         .catch(err => ("Couldn't call endpoint"));
     });
@@ -134,9 +127,9 @@ describe('getSkipSegments', () => {
                     let success = true;
                     for (const segment of data) {
                         if ((segment.segment[0] !== 20 || segment.segment[1] !== 33
-                            || segment.category !== "intro" || segment.UUID !== "1-uuid-7" || segment.videoDuration === 500) &&
+                            || segment.category !== "intro" || segment.UUID !== "1-uuid-7") &&
                             (segment.segment[0] !== 1 || segment.segment[1] !== 11
-                                || segment.category !== "intro" || segment.UUID !== "1-uuid-6" || segment.videoDuration === 400)) {
+                                || segment.category !== "intro" || segment.UUID !== "1-uuid-6")) {
                             success = false;
                             break;
                         }

--- a/test/cases/getSkipSegments.ts
+++ b/test/cases/getSkipSegments.ts
@@ -22,111 +22,111 @@ describe('getSkipSegments', () => {
     });
 
 
-    it('Should be able to get a time by category 1', () => {
+    it('Should be able to get a time by category 1', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest&category=sponsor")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200) done("Status code was: " + res.status);
             else {
                 const data = await res.json();
                 if (data.length === 1 && data[0].segment[0] === 1 && data[0].segment[1] === 11
                     && data[0].category === "sponsor" && data[0].UUID === "1-uuid-0" && data[0].videoDuration === 100) {
-                    return;
+                    done();
                 } else {
-                    return ("Received incorrect body: " + (await res.text()));
+                    done("Received incorrect body: " + (await res.text()));
                 }
             }
         })
         .catch(err => "Couldn't call endpoint");
     });
 
-    it('Should be able to get a time by category for a different service 1', () => {
-        fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest&category=sponsor&service=PeerTube")
+    it('Should be able to get a time by category for a different service 1', (done: Done) => {
+        fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest2&category=sponsor&service=PeerTube")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200) done("Status code was: " + res.status);
             else {
                 const data = await res.json();
                 if (data.length === 1 && data[0].segment[0] === 1 && data[0].segment[1] === 11
                     && data[0].category === "sponsor" && data[0].UUID === "1-uuid-0-1" && data[0].videoDuration === 120) {
-                    return;
+                    done();
                 } else {
-                    return ("Received incorrect body: " + (await res.text()));
+                    done("Received incorrect body: " + (await res.text()));
                 }
             }
         })
         .catch(err => "Couldn't call endpoint");
     });
 
-    it('Should be able to get a time by category 2', () => {
+    it('Should be able to get a time by category 2', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest&category=intro")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200) done("Status code was: " + res.status);
             else {
                 const data = await res.json();
                 if (data.length === 1 && data[0].segment[0] === 20 && data[0].segment[1] === 33
                     && data[0].category === "intro" && data[0].UUID === "1-uuid-2") {
-                    return;
+                    done();
                 } else {
-                    return ("Received incorrect body: " + (await res.text()));
+                    done("Received incorrect body: " + (await res.text()));
                 }
             }
         })
         .catch(err => ("Couldn't call endpoint"));
     });
 
-    it('Should be able to get a time by categories array', () => {
+    it('Should be able to get a time by categories array', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest&categories=[\"sponsor\"]")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200) done("Status code was: " + res.status);
             else {
                 const data = await res.json();
                 if (data.length === 1 && data[0].segment[0] === 1 && data[0].segment[1] === 11
                     && data[0].category === "sponsor" && data[0].UUID === "1-uuid-0" && data[0].videoDuration === 100) {
-                    return;
+                    done();
                 } else {
-                    return ("Received incorrect body: " + (await res.text()));
+                    done("Received incorrect body: " + (await res.text()));
                 }
             }
         })
         .catch(err => ("Couldn't call endpoint"));
     });
 
-    it('Should be able to get a time by categories array 2', () => {
+    it('Should be able to get a time by categories array 2', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest&categories=[\"intro\"]")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200) done("Status code was: " + res.status);
             else {
                 const data = await res.json();
                 if (data.length === 1 && data[0].segment[0] === 20 && data[0].segment[1] === 33
                     && data[0].category === "intro" && data[0].UUID === "1-uuid-2" && data[0].videoDuration === 101) {
-                    return;
+                    done();
                 } else {
-                    return ("Received incorrect body: " + (await res.text()));
+                    done("Received incorrect body: " + (await res.text()));
                 }
             }
         })
         .catch(err => ("Couldn't call endpoint"));
     });
 
-    it('Should be empty if all submissions are hidden', () => {
+    it('Should be empty if all submissions are hidden', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=onlyHiddenSegments")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200) done("Status code was: " + res.status);
             else {
                 const data = await res.json();
                 if (data.length === 0) {
-                    return;
+                    done();
                 } else {
-                    return ("Received incorrect body: " + (await res.text()));
+                    done("Received incorrect body: " + (await res.text()));
                 }
             }
         })
         .catch(err => ("Couldn't call endpoint"));
     });
 
-    it('Should be able to get multiple times by category', () => {
+    it('Should be able to get multiple times by category', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=multiple&categories=[\"intro\"]")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200)done("Status code was: " + res.status);
             else {
                 const body = await res.text();
                 const data = JSON.parse(body);
@@ -142,20 +142,20 @@ describe('getSkipSegments', () => {
                         }
                     }
 
-                    if (success) return;
-                    else return ("Received incorrect body: " + body);
+                    if (success) done();
+                    else done("Received incorrect body: " + body);
                 } else {
-                    return ("Received incorrect body: " + body);
+                    done("Received incorrect body: " + body);
                 }
             }
         })
         .catch(err => ("Couldn't call endpoint\n\n" + err));
     });
 
-    it('Should be able to get multiple times by multiple categories', () => {
+    it('Should be able to get multiple times by multiple categories', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest&categories=[\"sponsor\", \"intro\"]")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200) done("Status code was: " + res.status);
             else {
                 const body = await res.text();
                 const data = JSON.parse(body);
@@ -172,91 +172,91 @@ describe('getSkipSegments', () => {
                         }
                     }
 
-                    if (success) return;
-                    else return ("Received incorrect body: " + body);
+                    if (success) done();
+                    else done("Received incorrect body: " + body);
                 } else {
-                    return ("Received incorrect body: " + body);
+                    done("Received incorrect body: " + body);
                 }
             }
         })
         .catch(err => ("Couldn't call endpoint"));
     });
 
-    it('Should be possible to send unexpected query parameters', () => {
+    it('Should be possible to send unexpected query parameters', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest&fakeparam=hello&category=sponsor")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200) done("Status code was: " + res.status);
             else {
                 const body = await res.text();
                 const data = JSON.parse(body);
                 if (data.length === 1 && data[0].segment[0] === 1 && data[0].segment[1] === 11
                     && data[0].category === "sponsor" && data[0].UUID === "1-uuid-0") {
-                    return;
+                    done();
                 } else {
-                    return ("Received incorrect body: " + body);
+                    done("Received incorrect body: " + body);
                 }
             }
         })
-        .catch(err => ("Couldn't call endpoint"));
+        .catch(err => done("Couldn't call endpoint"));
     });
 
-    it('Low voted submissions should be hidden', () => {
+    it('Low voted submissions should be hidden', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=test3&category=sponsor")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200) done("Status code was: " + res.status);
             else {
                 const body = await res.text();
                 const data = JSON.parse(body);
                 if (data.length === 1 && data[0].segment[0] === 1 && data[0].segment[1] === 11
                     && data[0].category === "sponsor" && data[0].UUID === "1-uuid-4") {
-                    return;
+                    done();
                 } else {
-                    return ("Received incorrect body: " + body);
+                    done("Received incorrect body: " + body);
                 }
             }
         })
         .catch(err => ("Couldn't call endpoint"));
     });
 
-    it('Should return 404 if no segment found', () => {
+    it('Should return 404 if no segment found', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=notarealvideo")
         .then(res => {
-            if (res.status !== 404) return ("non 404 respone code: " + res.status);
-            else return; // pass
+            if (res.status !== 404) done("non 404 respone code: " + res.status);
+            else done(); // pass
         })
         .catch(err => ("couldn't call endpoint"));
     });
 
 
-    it('Should be able send a comma in a query param', () => {
+    it('Should be able send a comma in a query param', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest,test&category=sponsor")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200) done ("Status code was: " + res.status);
             else {
                 const body = await res.text();
                 const data = JSON.parse(body);
                 if (data.length === 1 && data[0].segment[0] === 1 && data[0].segment[1] === 11
                     && data[0].category === "sponsor" && data[0].UUID === "1-uuid-1") {
-                    return;
+                    done();
                 } else {
-                    return ("Received incorrect body: " + body);
+                    done("Received incorrect body: " + body);
                 }
             }
         })
         .catch(err => ("Couldn't call endpoint"));
     });
 
-    it('Should always get locked segment', () => {
+    it('Should always get locked segment', (done: Done) => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=locked&category=intro")
         .then(async res => {
-            if (res.status !== 200) return ("Status code was: " + res.status);
+            if (res.status !== 200) done ("Status code was: " + res.status);
             else {
                 const data = await res.json();
                 if (data.length === 1 && data[0].segment[0] === 20 && data[0].segment[1] === 33
                     && data[0].category === "intro" && data[0].UUID === "1-uuid-locked-8") {
-                    return;
+                    done();
                 } else {
-                    return ("Received incorrect body: " + (await res.text()));
+                    done("Received incorrect body: " + (await res.text()));
                 }
             }
         })

--- a/test/cases/getUserInfo.ts
+++ b/test/cases/getUserInfo.ts
@@ -80,19 +80,18 @@ describe('getUserInfo', () => {
         .catch(err => ("couldn't call endpoint"));
     });
 
-    it('Should get warning data with public ID', async () => {
-        try {
-            const res = await fetch(getbaseURL() + '/api/userInfo?userID=' + await getHash("getuserinfo_warning_0"))
-            
+    it('Should get warning data with public ID', (done: Done) => {
+        fetch(getbaseURL() + '/api/userInfo?publicUserID=' + getHash("getuserinfo_warning_0"))
+        .then(async res => {
             if (res.status !== 200) {
-                return 'non 200 (' + res.status + ')';
+                done('non 200 (' + res.status + ')');
             } else {
-                const data = await res.json();;
-                if (data.warnings !== 1) return 'wrong number of warnings: ' + data.warnings + ', not ' + 1;
+                const data = await res.json();
+                if (data.warnings !== 1) done('wrong number of warnings: ' + data.warnings + ', not ' + 1);
+                else done();
             }
-        } catch (err) {
-            return "couldn't call endpoint";
-        }
+        })
+        .catch(err => ("couldn't call endpoint"));
     });
 
     it('Should get multiple warnings', (done: Done) => {


### PR DESCRIPTION
This can be tested, quite easily by making the API only return errors and not seeing any errors from `/getSkipSegments`

src/routes/getSkipSegments.ts
```ts
async function endpoint(req: Request, res: Response): Promise<void> {
  res.status(500).send();
}
```

Currently this creates two failures in tests, since the expected responses have changed.


### 1 - getSkipSegments | Should be empty if all submissions are hidden
Expected: getSkipSegments should receive an empty body if all submissions are hidden
Actual: getSkipSegments returns 404 https://github.com/ajayyy/SponsorBlockServer/blob/87c6dab41d4ca29bb8ea8160c6fc99b9d8bbe94d/src/routes/getSkipSegments.ts#L290-L291

### 2 - getSkipSegments | Should be able to get multiple times by category
Expected: multiple segments should be returned
Actual: Only one segment (1-uuid-6) is returned, since the videoDuration is smaller

