### PR TITLE
skipSegments return 400 if bad categories

### DIFF
--- a/src/routes/getSkipSegments.ts
+++ b/src/routes/getSkipSegments.ts
@@ -306,7 +306,9 @@ async function endpoint(req: Request, res: Response): Promise<void> {
             res.send(segments);
         }
     } catch (err) {
-        res.status(500).send();
+        if (err instanceof SyntaxError) {
+            res.status(400).send("Categories parameter does not match format requirements.");
+        } else res.status(500).send();
     }
 }
 

--- a/test/cases/getSkipSegments.ts
+++ b/test/cases/getSkipSegments.ts
@@ -227,6 +227,14 @@ describe('getSkipSegments', () => {
         .catch(err => ("couldn't call endpoint"));
     });
 
+    it('Should return 400 if bad categories argument', (done: Done) => {
+        fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest&categories=[not-quoted,not-quoted]")
+        .then(res => {
+            if (res.status !== 400) done("non 400 respone code: " + res.status);
+            else done(); // pass
+        })
+        .catch(err => ("couldn't call endpoint"));
+    });
 
     it('Should be able send a comma in a query param', () => {
         fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest,test&category=sponsor")


### PR DESCRIPTION
currently, if `JSON.parse` fails, 500 is returned. This is not unexpected but it should give a more specific response like 400