### PR TITLE
parse repeated parameters

### DIFF
--- a/src/routes/getSegmentInfo.ts
+++ b/src/routes/getSegmentInfo.ts
@@ -29,10 +29,12 @@ async function getSegmentsByUUID(UUIDs: SegmentUUID[]): Promise<DBSegment[]> {
 async function handleGetSegmentInfo(req: Request, res: Response) {
     // If using params instead of JSON, only one UUID can be pulled
     let UUIDs = req.query.UUIDs
-    ? JSON.parse(req.query.UUIDs as string)
-    : req.query.UUID
-        ? [req.query.UUID]
-        : null;
+        ? JSON.parse(req.query.UUIDs as string)
+        : req.query.UUID
+            ? Array.isArray(req.query.UUID)
+                ? req.query.UUID
+                : [req.query.UUID]
+            : null;
     // deduplicate with set
     UUIDs = [ ...new Set(UUIDs)];
     // if more than 10 entries, slice

--- a/src/routes/getSkipSegments.ts
+++ b/src/routes/getSkipSegments.ts
@@ -268,7 +268,9 @@ async function handleGetSegments(req: Request, res: Response): Promise<Segment[]
     const categories = req.query.categories
         ? JSON.parse(req.query.categories as string)
         : req.query.category
-            ? [req.query.category]
+            ? Array.isArray(req.query.category)
+                ? req.query.category
+                : [req.query.category]
             : ['sponsor'];
     if (!Array.isArray(categories)) {
         res.status(400).send("Categories parameter does not match format requirements.");

--- a/test/cases/getSegmentInfo.ts
+++ b/test/cases/getSegmentInfo.ts
@@ -309,4 +309,22 @@ describe('getSegmentInfo', () => {
         })
         .catch(err => ("couldn't call endpoint"));
     });
+
+    it('Should be able to retreive multiple segments with multiple parameters', (done: Done) => {
+        fetch(getbaseURL() + `/api/segmentInfo?UUID=${upvotedID}&UUID=${downvotedID}`)
+        .then(async res => {
+            if (res.status !== 200) done("Status code was: " + res.status);
+            else {
+                const data = await res.json();
+                if (data.length === 2 &&
+                    (data[0].videoID === "upvoted" && data[0].votes === 2) &&
+                    (data[1].videoID === "downvoted" && data[1].votes === -2)) {
+                    done();
+                } else {
+                    done("Received incorrect body: " + (await res.text()));
+                }
+            }
+        })
+        .catch(err => "Couldn't call endpoint");
+    });
 });

--- a/test/cases/getSkipSegments.ts
+++ b/test/cases/getSkipSegments.ts
@@ -264,4 +264,33 @@ describe('getSkipSegments', () => {
         .catch(err => ("Couldn't call endpoint"));
     });
 
+    it('Should be able to get multiple categories with repeating parameters', (done: Done) => {
+        fetch(getbaseURL() + "/api/skipSegments?videoID=testtesttest&category=sponsor&category=intro")
+        .then(async res => {
+            if (res.status !== 200) done("Status code was: " + res.status);
+            else {
+                const body = await res.text();
+                const data = JSON.parse(body);
+                if (data.length === 2) {
+
+                    let success = true;
+                    for (const segment of data) {
+                        if ((segment.segment[0] !== 20 || segment.segment[1] !== 33
+                            || segment.category !== "intro" || segment.UUID !== "1-uuid-2") &&
+                            (segment.segment[0] !== 1 || segment.segment[1] !== 11
+                                || segment.category !== "sponsor" || segment.UUID !== "1-uuid-0")) {
+                            success = false;
+                            break;
+                        }
+                    }
+
+                    if (success) done();
+                    else done("Received incorrect body: " + body);
+                } else {
+                    done("Received incorrect body: " + body);
+                }
+            }
+        })
+        .catch(err => ("Couldn't call endpoint"));
+    });
 });


### PR DESCRIPTION
closes #235 

When parameters are repeated express passes them in as an array https://expressjs.com/en/5x/api.html#req.query

Added logic in query parsing and related tests