### PR TITLE
Appease eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "dev:bash": "nodemon -x 'npm test ; npm start'",
     "start": "ts-node src/index.ts",
     "tsc": "tsc -p tsconfig.json",
-    "lint": "eslint src",
-    "lint:fix": "eslint src --fix"
+    "lint": "eslint src test",
+    "lint:fix": "eslint src test --fix"
   },
   "author": "Ajay Ramachandran",
   "license": "MIT",

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,7 +84,6 @@ addDefaults(config, {
 function addDefaults(config: SBSConfig, defaults: SBSConfig) {
     for (const key in defaults) {
         if (!Object.prototype.hasOwnProperty.call(config, key)) {
-            // @ts-ignore
             config[key] = defaults[key];
         }
     }

--- a/src/types/config.model.ts
+++ b/src/types/config.model.ts
@@ -3,6 +3,7 @@ import * as redis from 'redis';
 import { CacheOptions } from "@ajayyy/lru-diskcache";
 
 export interface SBSConfig {
+    [index: string]: any
     port: number;
     mockPort?: number;
     globalSalt: string;

--- a/src/utils/createMemoryCache.ts
+++ b/src/utils/createMemoryCache.ts
@@ -1,4 +1,4 @@
-export function createMemoryCache(memoryFn: (...args: any[]) => void, cacheTimeMs: number) {
+export function createMemoryCache(memoryFn: (...args: any[]) => void, cacheTimeMs: number): any {
     if (isNaN(cacheTimeMs)) cacheTimeMs = 0;
 
     // holds the promise results
@@ -22,8 +22,8 @@ export function createMemoryCache(memoryFn: (...args: any[]) => void, cacheTimeM
                 }
             }
             // create new promise
-            const promise = new Promise(async (resolve) => {
-                resolve((await memoryFn(...args)));
+            const promise = new Promise((resolve) => {
+                resolve(memoryFn(...args));
             });
             // store promise reference until fulfilled
             promiseMemory.set(cacheKey, promise);

--- a/src/utils/diskCache.ts
+++ b/src/utils/diskCache.ts
@@ -8,6 +8,7 @@ if (config.diskCache) {
     DiskCache.init();
 } else {
     DiskCache = {
+        /* eslint-disable @typescript-eslint/no-unused-vars */
         // constructor(rootPath, options): {};
 
         init(): void { return; },
@@ -16,16 +17,17 @@ if (config.diskCache) {
 
         has(key: string): boolean { return false; },
 
-        get(key: string, opts): string { return null; },
+        get(key: string, opts?: {encoding?: string}): string { return null; },
 
         // Returns size
-        set(key: string, dataOrSteam): Promise<number> { return new Promise(() => 0); },
+        set(key: string, dataOrSteam: string): Promise<number> { return new Promise(() => 0); },
 
         del(key: string): void { return; },
 
         size(): number { return 0; },
 
         prune(): void {return; },
+        /* eslint-enable @typescript-eslint/no-unused-vars */
     };
 }
 

--- a/test/cases/getSkipSegments.ts
+++ b/test/cases/getSkipSegments.ts
@@ -326,7 +326,7 @@ describe('getSkipSegments', () => {
                 else done();
             }
         })
-        .catch(err => done("Couldn't call endpoint"));
+        .catch(() => done("Couldn't call endpoint"));
     });
 
     it('Should be able to get specific segments with repeating requiredSegment', (done: Done) => {
@@ -341,6 +341,6 @@ describe('getSkipSegments', () => {
                 else done();
             }
         })
-        .catch(err => done("Couldn't call endpoint"));
+        .catch(() => done("Couldn't call endpoint"));
     });
 });

--- a/test/cases/getSkipSegmentsByHash.ts
+++ b/test/cases/getSkipSegmentsByHash.ts
@@ -252,7 +252,7 @@ describe('getSegmentsByHash', () => {
                 }
             }
         })
-        .catch(err => ("Couldn't call endpoint"));
+        .catch(() => ("Couldn't call endpoint"));
     });
 
     it('Should be able to get specific segments with requiredSegments', (done: Done) => {
@@ -268,7 +268,7 @@ describe('getSegmentsByHash', () => {
                 else done();
             }
         })
-        .catch(err => done("Couldn't call endpoint"));
+        .catch(() => done("Couldn't call endpoint"));
     });
 
     it('Should be able to get specific segments with repeating requiredSegment', (done: Done) => {
@@ -284,6 +284,6 @@ describe('getSegmentsByHash', () => {
                 else done();
             }
         })
-        .catch(err => done("Couldn't call endpoint"));
+        .catch(() => done("Couldn't call endpoint"));
     });
 });

--- a/test/cases/getUserInfo.ts
+++ b/test/cases/getUserInfo.ts
@@ -165,7 +165,7 @@ describe('getUserInfo', () => {
             const data = await res.json();
             for (const value in data) {
                 if (data[value] === null && value !== "lastSegmentID")  {
-                    done(`returned null for ${value}`)
+                    done(`returned null for ${value}`);
                 }
             }
             done(); // pass

--- a/test/cases/setUsername.ts
+++ b/test/cases/setUsername.ts
@@ -46,6 +46,7 @@ async function getLastLogUserNameChange(userID: string) {
 }
 
 function wellFormatUserName(userName: string) {
+    // eslint-disable-next-line no-control-regex
     return userName.replace(/[\u0000-\u001F\u007F-\u009F]/g, '');
 }
 

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import {config} from '../src/config';
+import { Server } from 'http';
 
 const app = express();
 
@@ -46,6 +47,6 @@ app.post('/CustomWebhook', (req, res) => {
     res.sendStatus(200);
 });
 
-export function createMockServer(callback: () => void) {
+export function createMockServer(callback: () => void): Server {
     return app.listen(config.mockPort, callback);
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -18,15 +18,15 @@ async function init() {
     }));
 
     // delete old test database
-    if (fs.existsSync(config.db)) fs.unlinkSync(config.db)
+    if (fs.existsSync(config.db)) fs.unlinkSync(config.db);
     if (fs.existsSync(config.privateDB)) fs.unlinkSync(config.privateDB);
 
     await initDb();
 
     const dbMode = config.mysql ? 'mysql'
         : config.postgres ? 'postgres'
-        : 'sqlite'
-    Logger.info('Database Mode: ' + dbMode)
+        : 'sqlite';
+    Logger.info('Database Mode: ' + dbMode);
 
     // Instantiate a Mocha instance.
     const mocha = new Mocha();


### PR DESCRIPTION
closes #297 

## ignored errors
https://github.com/ajayyy/SponsorBlockServer/blob/d29c9613b92afa860aec551135711c6d84cb8022/src/databases/Mysql.ts#L3-L5

- This has to be ignored since sync-mysql does not have typings

https://github.com/ajayyy/SponsorBlockServer/blob/d29c9613b92afa860aec551135711c6d84cb8022/src/routes/postSkipSegments.ts#L474-L476
https://github.com/ajayyy/SponsorBlockServer/blob/d29c9613b92afa860aec551135711c6d84cb8022/src/routes/postSkipSegments.ts#L486-L488

- Only alternative to commenting out the lines

https://github.com/ajayyy/SponsorBlockServer/blob/d29c9613b92afa860aec551135711c6d84cb8022/src/routes/setUsername.ts#L30-L33

- removing control characters, so they have to be referenced in regex

https://github.com/ajayyy/SponsorBlockServer/blob/d29c9613b92afa860aec551135711c6d84cb8022/src/utils/diskCache.ts#L10-L31

- They're not supposed to return anything - having them use the variables would defeat the purpose and not having them take variables would cause errors