### PR TITLE
getLockReason

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -37,6 +37,7 @@ import {getLockCategories} from "./routes/getLockCategories";
 import {getLockCategoriesByHash} from "./routes/getLockCategoriesByHash";
 import {endpoint as getSearchSegments } from "./routes/getSearchSegments";
 import {getStatus } from "./routes/getStatus";
+import { getLockReason } from "./routes/getLockReason";
 import ExpressPromiseRouter from "express-promise-router";
 import { Server } from "http";
 import { youtubeApiProxy } from "./routes/youtubeApiProxy";
@@ -175,6 +176,8 @@ function setupRoutes(router: Router) {
     router.get("/api/status", getStatus);
 
     router.get("/api/youtubeApiProxy", youtubeApiProxy);
+
+    router.get("/api/lockReason", getLockReason);
 
     if (config.postgres) {
         router.get("/database", (req, res) => dumpDatabase(req, res, true));

--- a/src/routes/getLockReason.ts
+++ b/src/routes/getLockReason.ts
@@ -1,0 +1,56 @@
+import {db} from "../databases/databases";
+import {Logger} from "../utils/logger";
+import {Request, Response} from "express";
+import { Category, VideoID } from "../types/segments.model";
+import {config} from "../config";
+
+export async function getLockCategories(req: Request, res: Response): Promise<Response> {
+    const videoID = req.query.videoID as VideoID;
+    let categories: Category[] = [];
+    try {
+        categories = req.query.categories
+            ? JSON.parse(req.query.categories as string)
+            : req.query.category
+                ? Array.isArray(req.query.category)
+                    ? req.query.category
+                    : [req.query.category]
+                : ["sponsor"];
+        if (!Array.isArray(categories)) {
+            return res.status(400).send("Categories parameter does not match format requirements.");
+        }
+    } catch(error) {
+        return res.status(400).send("Bad parameter: categories (invalid JSON)");
+    }
+
+    if (videoID == undefined) {
+        //invalid request
+        return res.sendStatus(400);
+    }
+
+    try {
+        // Get existing lock categories markers
+        const row = await db.prepare("all", 'SELECT "category", "reason" from "lockCategories" where "videoID" = ?', [videoID]) as {category: Category, reason: string}[];
+        // map to object array
+        const locks = [];
+        for (const lock of row) {
+            locks.push({
+                category: lock.category,
+                locked: 1,
+                reason: lock.reason
+            });
+        }
+        const notLocked = categories.filter(reqCategory => config.categoryList.includes(reqCategory));
+        for (const noLock of notLocked) {
+            locks.push({
+                category: noLock,
+                locked: 0,
+                reason: ""
+            });
+        }
+        const filtered = locks.filter(lock => categories.includes(lock.category));
+        return res.send(...filtered, ...notLocked );
+    } catch (err) {
+        Logger.error(err as string);
+        return res.sendStatus(500);
+    }
+}

--- a/src/routes/getLockReason.ts
+++ b/src/routes/getLockReason.ts
@@ -11,7 +11,7 @@ interface lockArray {
     reason: string
 }
 
-export async function getLockCategories(req: Request, res: Response): Promise<Response> {
+export async function getLockReason(req: Request, res: Response): Promise<Response> {
     const videoID = req.query.videoID as VideoID;
     let categories: Category[] = [];
     try {

--- a/src/routes/getLockReason.ts
+++ b/src/routes/getLockReason.ts
@@ -4,6 +4,13 @@ import {Request, Response} from "express";
 import { Category, VideoID } from "../types/segments.model";
 import {config} from "../config";
 
+const possibleCategoryList = config.categoryList;
+interface lockArray {
+    category: Category;
+    locked: number,
+    reason: string
+}
+
 export async function getLockCategories(req: Request, res: Response): Promise<Response> {
     const videoID = req.query.videoID as VideoID;
     let categories: Category[] = [];
@@ -14,13 +21,15 @@ export async function getLockCategories(req: Request, res: Response): Promise<Re
                 ? Array.isArray(req.query.category)
                     ? req.query.category
                     : [req.query.category]
-                : ["sponsor"];
+                : []; // default to empty, will be set to all
         if (!Array.isArray(categories)) {
             return res.status(400).send("Categories parameter does not match format requirements.");
         }
     } catch(error) {
         return res.status(400).send("Bad parameter: categories (invalid JSON)");
     }
+    // only take valid categories
+    const searchCategories = (categories.length === 0 ) ? possibleCategoryList : categories.filter(x => possibleCategoryList.includes(x));
 
     if (videoID == undefined) {
         //invalid request
@@ -32,23 +41,28 @@ export async function getLockCategories(req: Request, res: Response): Promise<Re
         const row = await db.prepare("all", 'SELECT "category", "reason" from "lockCategories" where "videoID" = ?', [videoID]) as {category: Category, reason: string}[];
         // map to object array
         const locks = [];
+        const lockedCategories = [] as string[];
+        // get all locks for video, check if requested later
         for (const lock of row) {
             locks.push({
                 category: lock.category,
                 locked: 1,
                 reason: lock.reason
-            });
+            } as lockArray);
+            lockedCategories.push(lock.category);
         }
-        const notLocked = categories.filter(reqCategory => config.categoryList.includes(reqCategory));
-        for (const noLock of notLocked) {
+        // add empty locks for categories requested but not locked
+        const noLockCategories = searchCategories.filter(x => !lockedCategories.includes(x));
+        for (const noLock of noLockCategories) {
             locks.push({
                 category: noLock,
                 locked: 0,
                 reason: ""
-            });
+            } as lockArray);
         }
-        const filtered = locks.filter(lock => categories.includes(lock.category));
-        return res.send(...filtered, ...notLocked );
+        // return real and fake locks that were requested
+        const filtered = locks.filter(lock => searchCategories.includes(lock.category));
+        return res.send(filtered);
     } catch (err) {
         Logger.error(err as string);
         return res.sendStatus(500);

--- a/test/cases/getLockReason.ts
+++ b/test/cases/getLockReason.ts
@@ -1,0 +1,119 @@
+import fetch from "node-fetch";
+import {Done, getbaseURL} from "../utils";
+import {getHash} from "../../src/utils/getHash";
+import {db} from "../../src/databases/databases";
+import assert from "assert";
+
+const endpoint = `${getbaseURL()}/api/lockReason`;
+
+describe("getLockReason", () => {
+    before(async () => {
+        const vipUserID = "getLockReasonVIP";
+        const vipUserHash = getHash(vipUserID);
+        const insertVipUserQuery = 'INSERT INTO "vipUsers" ("userID") VALUES (?)';
+        await db.prepare("run", insertVipUserQuery, [vipUserHash]);
+        await db.prepare("run", insertVipUserQuery, [vipUserHash]);
+
+        const insertLockCategoryQuery = 'INSERT INTO "lockCategories" ("userID", "videoID", "category", "reason") VALUES (?, ?, ?, ?)';
+        await db.prepare("run", insertLockCategoryQuery, [vipUserHash, "getLockReason", "sponsor", "sponsor-reason"]);
+        await db.prepare("run", insertLockCategoryQuery, [vipUserHash, "getLockReason", "interaction", "interaction-reason"]);
+        await db.prepare("run", insertLockCategoryQuery, [vipUserHash, "getLockReason", "preview", "preview-reason"]);
+        await db.prepare("run", insertLockCategoryQuery, [vipUserHash, "getLockReason", "music_offtopic", "nonmusic-reason"]);
+    });
+
+    it("Should update the database version when starting the application", async () => {
+        const version = (await db.prepare("get", "SELECT key, value FROM config where key = ?", ["version"])).value;
+        if (version > 20) return;
+        else return `Version isn't greater than 20. Version is ${version}`;
+    });
+
+    it("Should be able to get single reason", (done: Done) => {
+        fetch(`${endpoint}?videoID=getLockReason&category=sponsor`)
+            .then(async res => {
+                assert.strictEqual(res.status, 200);
+                const data = await res.json();
+                const expected = [
+                    { category: "sponsor", locked: 1, reason: "sponsor-reason" }
+                ];
+                assert.deepStrictEqual(data, expected);
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it("Should be able to get empty locks", (done: Done) => {
+        fetch(`${endpoint}?videoID=getLockReason&category=intro`)
+            .then(async res => {
+                assert.strictEqual(res.status, 200);
+                const data = await res.json();
+                const expected = [
+                    { category: "intro", locked: 0, reason: "" }
+                ];
+                assert.deepStrictEqual(data, expected);
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it("should get multiple locks with array", (done: Done) => {
+        fetch(`${endpoint}?videoID=getLockReason&categories=["intro","sponsor"]`)
+            .then(async res => {
+                assert.strictEqual(res.status, 200);
+                const data = await res.json();
+                const expected = [
+                    { category: "sponsor", locked: 1, reason: "sponsor-reason" },
+                    { category: "intro", locked: 0, reason: ""}
+                ];
+                assert.deepStrictEqual(data, expected);
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it("should get multiple locks with repeated category", (done: Done) => {
+        fetch(`${endpoint}?videoID=getLockReason&category=interaction&category=music_offtopic&category=intro`)
+            .then(async res => {
+                assert.strictEqual(res.status, 200);
+                const data = await res.json();
+                const expected = [
+                    { category: "interaction", locked: 1, reason: "interaction-reason" },
+                    { category: "music_offtopic", locked: 1, reason: "nonmusic-reason" },
+                    { category: "intro", locked: 0, reason: "" }
+                ];
+                assert.deepStrictEqual(data, expected);
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it("should return all categories if none specified", (done: Done) => {
+        fetch(`${endpoint}?videoID=getLockReason`)
+            .then(async res => {
+                assert.strictEqual(res.status, 200);
+                const data = await res.json();
+                console.log(data);
+                const expected = [
+                    { category: "sponsor", locked: 1, reason: "sponsor-reason" },
+                    { category: "interaction", locked: 1, reason: "interaction-reason" },
+                    { category: "preview", locked: 1, reason: "preview-reason" },
+                    { category: "music_offtopic", locked: 1, reason: "nonmusic-reason" },
+                    { category: "selfpromo", locked: 0, reason: "" },
+                    { category: "intro", locked: 0, reason: "" },
+                    { category: "outro", locked: 0, reason: "" },
+                    { category: "poi_highlight", locked: 0, reason: "" }
+                ];
+                assert.deepStrictEqual(data, expected);
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it("should return 400 if no videoID specified", (done: Done) => {
+        fetch(endpoint)
+            .then(res => {
+                assert.strictEqual(res.status, 400);
+                done();
+            })
+            .catch(err => done(err));
+    });
+});


### PR DESCRIPTION
API Proposal

GET /api/lockReason

Input (URL Parameters)
```ts
{
  videoID: string
  
  // categories to get reasons for, defaults to all
  category: string
  // OR
  categories: string[]
}
```
Response

If not locked, it will return locked 0 and reason ""
```ts
[{ // array of requested categories
  category: string
  locked: integer
  reason: string
}]
```

I didn't want to add this to `getLockCategories` since it should only return the categories and this one is specifically to return the reasons for the locks