### PR TITLE
NGINX transparent gzip compression

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -17,6 +17,10 @@ http {
 	include		/etc/nginx/mime.types;
 	include		/etc/nginx/proxy.conf;
 	include		/etc/nginx/fastcgi.conf;
+	## Custom MIME definition
+	types {
+		text/csv	csv;
+	}
 
 	upstream backend_GET {
 		least_conn;
@@ -124,7 +128,8 @@ http {
 		location /download/ {
 			access_log /etc/nginx/logs/download.log no_ip;
 			gzip on;
-			gzip_types	text/plain application/json;
+			gzip_types	text/csv;
+			gzip_comp_level 1;
 			alias		/home/sbadmin/sponsor/docker/database-export/;
 			#return 307 https://cdnsponsor.ajay.app$request_uri;
 		}


### PR DESCRIPTION
Implements transparent compression for NGINX (https://github.com/ajayyy/SponsorBlockServer/issues/373#issuecomment-935015902)

since nginx only natively supports gzip, it was selected. 

### Breakdown of levels vs size and time

Tests ran on a Ryzen 5 3600 / 16GB DDR4 3200 / WD SN750 NVMe SSD
| level 	| time(s)	| size(b) 	| size(MB) 	| % 	|
|---	|:---:	|:---:	|:---:	|:---:	|
| 0 	| 0 	| 665351423 	| 665.351423 	| 100.00% 	|
| 1 	| 22.775 	| 287508099 	| 287.508099 	| 43.21% 	|
| 2 	| 22.29 	| 287508099 	| 287.508099 	| 43.21% 	|
| 3 	| 22.664 	| 287508099 	| 287.508099 	| 43.21% 	|
| 4 	| 22.654 	| 287508099 	| 287.508099 	| 43.21% 	|
| 5 	| 25.573 	| 285194714 	| 285.194714 	| 42.86% 	|
| 6 	| 27.551 	| 284441464 	| 284.441464 	| 42.75% 	|
| 7 	| 27.846 	| 284197581 	| 284.197581 	| 42.71% 	|
| 8 	| 31.404 	| 284196328 	| 284.196328 	| 42.71% 	|
| 9 	| 31.792 	| 284196328 	| 284.196328 	| 42.71% 	|

There does seem to be much better results with zstd but that might be better for replication