### PR TITLE
fix fragment in links

### DIFF
--- a/src/routes/postSkipSegments.ts
+++ b/src/routes/postSkipSegments.ts
@@ -83,7 +83,7 @@ async function sendWebhooks(apiVideoInfo: APIVideoInfo, userID: string, videoID:
         axios.post(config.discordFirstTimeSubmissionsWebhookURL, {
             "embeds": [{
                 "title": data?.title,
-                "url": `https://www.youtube.com/watch?v=${videoID}&t=${(parseInt(startTime.toFixed(0)) - 2)}#requiredSegment=${UUID}`,
+                "url": `https://www.youtube.com/watch?v=${videoID}&t=${(parseInt(startTime.toFixed(0)) - 2)}s#requiredSegment=${UUID}`,
                 "description": `Submission ID: ${UUID}\
                     \n\nTimestamp: \
                     ${getFormattedTime(startTime)} to ${getFormattedTime(endTime)}\

--- a/src/routes/voteOnSponsorTime.ts
+++ b/src/routes/voteOnSponsorTime.ts
@@ -114,7 +114,7 @@ async function sendWebhooks(voteData: VoteData) {
                 axios.post(webhookURL, {
                     "embeds": [{
                         "title": data?.title,
-                        "url": `https://www.youtube.com/watch?v=${submissionInfoRow.videoID}&t=${(submissionInfoRow.startTime.toFixed(0) - 2)}#requiredSegment=${voteData.UUID}`,
+                        "url": `https://www.youtube.com/watch?v=${submissionInfoRow.videoID}&t=${(submissionInfoRow.startTime.toFixed(0) - 2)}s#requiredSegment=${voteData.UUID}`,
                         "description": `**${voteData.row.votes} Votes Prior | \
                             ${(voteData.row.votes + voteData.incrementAmount - voteData.oldIncrementAmount)} Votes Now | ${voteData.row.views} \
                             Views**\n\n**Submission ID:** ${voteData.UUID}\


### PR DESCRIPTION
for some reason the ?t=second syntax is inappropriate, YT will actually convert it and in doing so remove the fragment

Test Links:
https://youtu.be/dQw4w9WgXcQ?t=111#extra=lorem
https://youtu.be/dQw4w9WgXcQ?t=111s#extra=lorem
https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=111#extra=lorem
https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=111s#extra=lorem

only the fourth, with the non-short link and `t=111s` will preserve the fragment

see also https://discord.com/channels/603643120093233162/603643299961503761/899926987932590101
