### PR TITLE
nginx tuning in lieu of http/2

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -21,6 +21,12 @@ http {
 	types {
 		text/csv	csv;
 	}
+	# keepalive settings
+	keepalive 					5;
+	keepalive_request		10;
+	keepalive_timeout		5;
+	proxy_http_version 1.1;
+	proxy_set_header Connection "";
 
 	upstream backend_GET {
 		ip_hash;
@@ -32,7 +38,7 @@ http {
 		#server		localhost:4446;
 		#server		localhost:4447;
 		#server		localhost:4448;
-                server 		10.0.0.4:4441;
+		server 		10.0.0.4:4441;
 
 		#server		10.0.0.3:4441;
 		server		10.0.0.3:4442;
@@ -60,8 +66,8 @@ http {
 	upstream backend_db {
 		server		10.0.0.4:4441;
 		#server		10.0.0.3:4441;
-	        #server		10.0.0.4; 
-        }
+		#server		10.0.0.4; 
+	}
 
 	upstream backend_db_dl {
 		server		10.0.0.4;
@@ -109,7 +115,7 @@ http {
 			#proxy_pass		https://sbtest.etcinit.com/;
 		}
 
-		#access_log /etc/nginx/logs/requests.log no_ip;
+		#access_log /etc/nginx/logs/requests.log no_ip buffer=64k;
 
 		location /api/skipSegments {
 			#return 200 "[]";
@@ -120,11 +126,11 @@ http {
 			#access_log /etc/nginx/logs/download.log no_ip;
 			gzip on;
 			if ($request_method = POST) {
-				access_log /etc/nginx/logs/submissions.log user_agent;
+				access_log /etc/nginx/logs/submissions.log user_agent buffer=64k;
 			}
 				
 			#proxy_read_timeout 6s;
-		        #proxy_next_upstream error timeout http_500 http_502;
+			#proxy_next_upstream error timeout http_500 http_502;
 		}
 
 		location /api/getTopUsers {
@@ -135,7 +141,7 @@ http {
 
 		location /api/getTotalStats {
 			proxy_pass http://backend_GET;
-                        proxy_cache CACHEZONE;
+			proxy_cache CACHEZONE;
 			proxy_cache_valid 20m;
 			#return 200 "";
 		}
@@ -145,15 +151,15 @@ http {
 		}
 
 		location /download/ {
-			#access_log /etc/nginx/logs/download.log no_ip;
+			#access_log /etc/nginx/logs/download.log no_ip buffer=64k;
 			gzip on;
-                        proxy_cache CACHEZONE;
+			proxy_cache CACHEZONE;
 			proxy_cache_valid 20m;
 			#gzip_types	text/csv;
 			#gzip_comp_level 1;
 			
 			proxy_pass  http://backend_db;
-                        #alias		/home/sbadmin/sponsor/docker/database-export/;
+      #alias		/home/sbadmin/sponsor/docker/database-export/;
 			#return 307 https://cdnsponsor.ajay.app$request_uri;
 		}
 		location /database {
@@ -196,15 +202,7 @@ http {
     ssl_certificate_key /etc/letsencrypt/live/sponsor.ajay.app-0001/privkey.pem; # managed by Certbot
 		include				/etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
 		ssl_dhparam			/etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-	
-
-
-
-
-
-
-
-}
+	}
 
 	server {
 		server_name cdnsponsor.ajay.app;
@@ -228,11 +226,7 @@ http {
     ssl_certificate_key /etc/letsencrypt/live/sponsor.ajay.app-0001/privkey.pem; # managed by Certbot
 		include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
 		ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-	
-
-
-
-}
+	}
 
 	server {
 		access_log off;
@@ -281,9 +275,5 @@ http {
     ssl_certificate_key /etc/letsencrypt/live/sponsor.ajay.app-0001/privkey.pem; # managed by Certbot
 		include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
 		ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
-	
-
-
-
-}
+	}
 }


### PR DESCRIPTION
- whitespace formatting
- added keepalive
- buffer access_logs
- friendship ended with http/2, nginx is my new best friend ([#420](https://github.com/ajayyy/SponsorBlockServer/issues/420#issuecomment-997301080))

documentation re: keepalive https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive