### PR TITLE
voteOnSponsorTime.ts: don't do database queries for vote eligibility on locked segments

### DIFF
--- a/src/routes/voteOnSponsorTime.ts
+++ b/src/routes/voteOnSponsorTime.ts
@@ -476,11 +476,11 @@ export async function vote(ip: IPAddress, UUID: SegmentUUID, paramUserID: UserID
 
         // Only change the database if they have made a submission before and haven't voted recently
         const userAbleToVote = (!(isOwnSubmission && incrementAmount > 0 && oldIncrementAmount >= 0)
+                && !finalResponse.blockVote
+                && finalResponse.finalStatus === 200
                 && (await db.prepare("get", `SELECT "userID" FROM "sponsorTimes" WHERE "userID" = ?`, [nonAnonUserID])) !== undefined
                 && (await db.prepare("get", `SELECT "userID" FROM "shadowBannedUsers" WHERE "userID" = ?`, [nonAnonUserID])) === undefined
-                && (await privateDB.prepare("get", `SELECT "UUID" FROM "votes" WHERE "UUID" = ? AND "hashedIP" = ? AND "userID" != ?`, [UUID, hashedIP, userID])) === undefined)
-                && !finalResponse.blockVote
-                && finalResponse.finalStatus === 200;
+                && (await privateDB.prepare("get", `SELECT "UUID" FROM "votes" WHERE "UUID" = ? AND "hashedIP" = ? AND "userID" != ?`, [UUID, hashedIP, userID])) === undefined);
 
 
         const ableToVote = isVIP || isTempVIP || userAbleToVote;


### PR DESCRIPTION
This PR fixes a small potential performance issue I found & reported on the discord server.
In theory, the server would do possibly expensive database queries to check if the user is eligible to vote, even if it already knows the vote will be blocked due to the segment being locked. I fixed this by simply moving the checks for pre-computed values `finalResponse.blockVote` and `finalResponse.finalStatus` up, so if any of those checks fail, the server should not attempt to query the database.

I ran tests after the change, no tests have failed.