### PR TITLE
docker build without platforms + bumped actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: |
             ghcr.io/${{ inputs.username }}/${{ inputs.name }}
@@ -30,21 +30,14 @@ jobs:
           flavor: |
             latest=true
       - name: Login to GHCR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GH_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: arm,arm64
-      - name: Set up buildx
-        uses: docker/setup-buildx-action@v1
       - name: push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
- bumped actions versions to support new runner version with min version node > 16
- removed QEMU setup since there are no multi builds
- removed buildx setup since there are no multi builds
- by default only target runner architecture (amd64)