### PR TITLE
add b2 syncing for sqlite base

### DIFF
--- a/.github/workflows/generate-sqlite-base.yml
+++ b/.github/workflows/generate-sqlite-base.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           name: SponsorTimesDB.db
           path: databases/sponsorTimes.db
-      - uses: mchangrh/s3cmd-sync@v1
+      - uses: mchangrh/s3cmd-sync@f4f36b9705bdd9af7ac91964136989ac17e3b513
         with:
           args: --acl-public
         env:

--- a/.github/workflows/generate-sqlite-base.yml
+++ b/.github/workflows/generate-sqlite-base.yml
@@ -26,3 +26,12 @@ jobs:
         with:
           name: SponsorTimesDB.db
           path: databases/sponsorTimes.db
+      - uses: mchangrh/s3cmd-sync@v1
+        with:
+          args: --acl-public
+        env:
+          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_ACCESS_KEY_SECRET: ${{ secrets.S3_ACCESS_KEY_SECRET }}
+          SOURCE_DIR: 'databases/sponsorTimes.db'


### PR DESCRIPTION
Implementation notes

this uses a custom GHA since the alternatives were horribly outdated https://github.com/mchangrh/s3cmd-sync

Secrets from B2 are as follows:
- read and write access is required to verify that files were uploaded
- `S3_ACCESS_KEY_ID` = keyID
- `S3_ACCESS_KEY_SECRET` = applicationKey
- `S3_BUCKET` = B2 bucket name
- `S3_ENDPOINT` = `s3.us-west-000.backblazeb2.com` or similar format