### PR TITLE
Some fixes for voteOnSponsorTime.ts

### DIFF
--- a/src/routes/voteOnSponsorTime.ts
+++ b/src/routes/voteOnSponsorTime.ts
@@ -14,6 +14,7 @@ import { DBSegment, Category, HashedIP, IPAddress, SegmentUUID, Service, VideoID
 import { QueryCacher } from "../utils/queryCacher";
 import axios from "axios";
 import { getVideoDetails, videoDetails } from "../utils/getVideoDetails";
+import { deleteLockCategories } from "./deleteLockCategories";
 
 const voteTypes = {
     normal: 0,
@@ -95,6 +96,7 @@ async function checkVideoDuration(UUID: SegmentUUID) {
             AND "hidden" = 0 AND "shadowHidden" = 0 AND 
             "actionType" != 'full' AND "votes" > -2`,
         [videoID, service, latestSubmission.timeSubmitted]);
+        deleteLockCategories(videoID, null, null, service).catch(Logger.error);
     }
 }
 

--- a/src/routes/voteOnSponsorTime.ts
+++ b/src/routes/voteOnSponsorTime.ts
@@ -221,7 +221,7 @@ async function categoryVote(UUID: SegmentUUID, userID: UserID, isVIP: boolean, i
         [UUID], { useReplica: true })) as {category: Category, actionType: ActionType, videoID: VideoID, hashedVideoID: VideoIDHash, service: Service, userID: UserID, locked: number};
 
     if (!config.categorySupport[category]?.includes(segmentInfo.actionType) || segmentInfo.actionType === ActionType.Full) {
-        return { status: 400, message: `Not allowed to change to ${category} when for segment of type ${segmentInfo.actionType}`};
+        return { status: 400, message: `Not allowed to change to ${category} when for segment of type ${segmentInfo.actionType}` };
     }
     if (!config.categoryList.includes(category)) {
         return { status: 400, message: "Category doesn't exist." };

--- a/src/routes/voteOnSponsorTime.ts
+++ b/src/routes/voteOnSponsorTime.ts
@@ -59,7 +59,7 @@ async function updateSegmentVideoDuration(UUID: SegmentUUID) {
     let apiVideoDetails: videoDetails = null;
     if (service == Service.YouTube) {
         // don't use cache since we have no information about the video length
-        apiVideoDetails = await getVideoDetails(videoID);
+        apiVideoDetails = await getVideoDetails(videoID, true);
     }
     const apiVideoDuration = apiVideoDetails?.duration as VideoDuration;
     if (videoDurationChanged(videoDuration, apiVideoDuration)) {


### PR DESCRIPTION
Initially reported [on discord](https://canary.discord.com/channels/603643120093233162/607338052221665320/1027213999919603792)
Changes in this PR:
* Actually ignore the cache in `updateSegmentVideoDuration`, as the comment above suggests 
* Delete category locks when a duration change is detected after voting
* Fixed the linter warning