### PR TITLE
Fixed minutesSaved typo

### DIFF
--- a/src/routes/getTopUsers.ts
+++ b/src/routes/getTopUsers.ts
@@ -33,7 +33,7 @@ async function generateTopUsersStats(sortBy: string, categoryStatsEnabled = fals
     }
 
     const rows = await db.prepare("all", `SELECT COUNT(*) as "totalSubmissions", SUM(views) as "viewCount",
-        SUM(CASE WHEN "sponsorTimes"."actionType" = 'chapter' THEN 0 ELSE ((CASE WHEN "sponsorTimes"."endTime" - "sponsorTimes"."startTime" > ? THEN ? ELSE "sponsorTimes"."endTime" - "sponsorTimes"."startTime" END) / 6) * "sponsorTimes"."views" END) as "minutesSaved",
+        SUM(CASE WHEN "sponsorTimes"."actionType" = 'chapter' THEN 0 ELSE ((CASE WHEN "sponsorTimes"."endTime" - "sponsorTimes"."startTime" > ? THEN ? ELSE "sponsorTimes"."endTime" - "sponsorTimes"."startTime" END) / 60) * "sponsorTimes"."views" END) as "minutesSaved",
         SUM("votes") as "userVotes", ${additionalFields} COALESCE("userNames"."userName", "sponsorTimes"."userID") as "userName" FROM "sponsorTimes" LEFT JOIN "userNames" ON "sponsorTimes"."userID"="userNames"."userID"
         LEFT JOIN "shadowBannedUsers" ON "sponsorTimes"."userID"="shadowBannedUsers"."userID"
         WHERE "sponsorTimes"."votes" > -1 AND "sponsorTimes"."shadowHidden" != 1 AND "shadowBannedUsers"."userID" IS NULL


### PR DESCRIPTION
The statistics from getTopUsers was off by a multiple of 10x

Response from getTopUsers:
```
#> curl -s "https://sponsor.ajay.app/api/getTopUsers?categoryStats=true&sortType=0&category=all" | jq '. | {userName: .userNames[0], minutesSaved: .minutesSaved[0]}'

{
  "userName": "Niros",
  "minutesSaved": 168006254.7019864
}
```

Response from userInfo for Niros:
```
#> curl -s "https://sponsor.ajay.app/api/userInfo?publicUserID=9897d3bc649a61a92e2cb47ba985d0bca90c9941ad8b24eca1aa65a9d6576092" | jq

{
  "userID": "9897d3bc649a61a92e2cb47ba985d0bca90c9941ad8b24eca1aa65a9d6576092",
  "userName": "Niros",
  "minutesSaved": 16934960.119486634,
  "segmentCount": 21589,
  "ignoredSegmentCount": 879,
  "viewCount": 25135914,
  "ignoredViewCount": 289791,
  "warnings": 0,
  "warningReason": "",
  "reputation": 27,
  "vip": true,
  "lastSegmentID": "af072dcd4152c495e9b06187b5e2b879bcad1368c7c008cde4e38b9f38a2af196"
}
```