### PR TITLE
Make voting requirements more strict

### DIFF
--- a/src/routes/voteOnSponsorTime.ts
+++ b/src/routes/voteOnSponsorTime.ts
@@ -470,16 +470,15 @@ export async function vote(ip: IPAddress, UUID: SegmentUUID, paramUserID: UserID
         }
 
         // Only change the database if they have made a submission before and haven't voted recently
-        const userAbleToVote = (!(isOwnSubmission && incrementAmount > 0 && oldIncrementAmount >= 0)
-                && !(originalType === VoteType.Malicious && segmentInfo.actionType !== ActionType.Chapter)
-                && !finalResponse.blockVote
-                && finalResponse.finalStatus === 200
-                && (await db.prepare("get", `SELECT "userID" FROM "sponsorTimes" WHERE "userID" = ?`, [nonAnonUserID], { useReplica: true })) !== undefined
-                && (await db.prepare("get", `SELECT "userID" FROM "shadowBannedUsers" WHERE "userID" = ?`, [nonAnonUserID], { useReplica: true })) === undefined
-                && (await privateDB.prepare("get", `SELECT "UUID" FROM "votes" WHERE "UUID" = ? AND "hashedIP" = ? AND "userID" != ?`, [UUID, hashedIP, userID], { useReplica: true })) === undefined);
-
-
-        const ableToVote = isVIP || isTempVIP || userAbleToVote;
+        const ableToVote = isVIP || isTempVIP || (
+            (!(isOwnSubmission && incrementAmount > 0 && oldIncrementAmount >= 0)
+            && !(originalType === VoteType.Malicious && segmentInfo.actionType !== ActionType.Chapter)
+            && !finalResponse.blockVote
+            && finalResponse.finalStatus === 200
+            && (await db.prepare("get", `SELECT "userID" FROM "sponsorTimes" WHERE "userID" = ? AND "category" = ? AND "votes" > -2 AND "hidden" = 0 AND "shadowHidden" = 0 LIMIT 1`, [nonAnonUserID, segmentInfo.category], { useReplica: true }) !== undefined)
+            && (await db.prepare("get", `SELECT "userID" FROM "shadowBannedUsers" WHERE "userID" = ?`, [nonAnonUserID], { useReplica: true })) === undefined
+            && (await privateDB.prepare("get", `SELECT "UUID" FROM "votes" WHERE "UUID" = ? AND "hashedIP" = ? AND "userID" != ?`, [UUID, hashedIP, userID], { useReplica: true })) === undefined)
+        );
 
         if (ableToVote) {
             //update the votes table


### PR DESCRIPTION
- [x] I agree to license my contribution under AGPL-3.0-only with my contribution automatically being licensed under LGPL-3.0 additionally after 6 months

***
This aims to reduce the amount of false votes by users with no valid segments of the category they're voting for.
New tests included, one modified to work under new requirements.
Also merged userAbleToVote and ableToVote in voteOnSponsorTime.ts to skip unnecessary queries for VIPs.