### PR TITLE
Fix 90% check making 0%-10% more likely to be picked for a thumbnail

### DIFF
--- a/src/routes/getBranding.ts
+++ b/src/routes/getBranding.ts
@@ -237,8 +237,10 @@ export function findRandomTime(videoID: VideoID, segments: BrandingSegmentDBResu
     let randomTime = SeedRandom.alea(videoID)();
 
     // Don't allow random times past 90% of the video if no endcard
-    if (!segments.some((s) => s.category === "outro") && randomTime > 0.9) {
-        randomTime -= 0.9;
+    if (!segments.some((s) => s.category === "outro")) {
+        // Since the randomTime is in range <0.0;1.0), *= 0.9 caps it to <0.0;0.9)
+        // without making some ranges more likely to be picked than others
+        randomTime *= 0.9;
     }
 
     if (segments.length === 0) return randomTime;


### PR DESCRIPTION
- [x] I agree to license my contribution under AGPL-3.0-only with my contribution automatically being licensed under LGPL-3.0 additionally after 6 months

***
While reading the DeArrow server code to reimplement it in DeArrow Browser, I've noticed that the way that the last 10% of a video is excluded from thumbnail picking makes picking times from the first 10% more likely. This is likely unintentional.
Remapping the 90%-100% range to 0%-10% (by subtracting 0.9) creates a second way for any number in the 0%-10% range to be picked, making them twice as likely to be picked as any number from any other range.
This PR instead scales the full 0%-100% range to 0-90%, keeping the odds of picking any number from that range roughly* equal. 

<sub>*float precision and whatever else may make some numbers more likely than others, but it's still better than being biased towards the first 10%</sub>