### PR TITLE
postBranding.ts webhook changes

### DIFF
--- a/src/routes/postBranding.ts
+++ b/src/routes/postBranding.ts
@@ -292,11 +292,30 @@ export async function verifyOldSubmissions(hashedUserID: HashedUserID, verificat
 }
 
 async function sendWebhooks(videoID: VideoID, UUID: BrandingUUID, voteType: BrandingVoteType) {
-    const currentSubmission = await db.prepare("get", `SELECT "titleVotes"."votes", "titles"."title", "titleVotes"."locked", "titles"."userID", "titleVotes"."votes"-"titleVotes"."downvotes"+"titleVotes"."verification" AS "score" FROM "titles" JOIN "titleVotes" ON "titles"."UUID" = "titleVotes"."UUID" WHERE "titles"."UUID" = ?`, [UUID]);
+    const currentSubmission = await db.prepare(
+        "get",
+        `SELECT 
+            "titles"."title", 
+            "titleVotes"."locked", 
+            "titles"."userID", 
+            "titleVotes"."votes"-"titleVotes"."downvotes"+"titleVotes"."verification" AS "score" 
+        FROM "titles" JOIN "titleVotes" ON "titles"."UUID" = "titleVotes"."UUID" 
+        WHERE "titles"."UUID" = ?`,
+        [UUID]);
 
     // Unlocked title getting more upvotes than the locked one
     if (voteType === BrandingVoteType.Upvote) {
-        const lockedSubmission = await db.prepare("get", `SELECT "titleVotes"."votes", "titles"."title", "titles"."userID", "titleVotes"."votes"-"titleVotes"."downvotes"+"titleVotes"."verification" AS "score"  FROM "titles" JOIN "titleVotes" ON "titles"."UUID" = "titleVotes"."UUID" WHERE "titles"."videoID" = ? AND "titles"."UUID" != ? AND "titleVotes"."locked" = 1`, [videoID, UUID]);
+        const lockedSubmission = await db.prepare(
+            "get",
+            `SELECT 
+                "titles"."title", 
+                "titles"."userID", 
+                "titleVotes"."votes"-"titleVotes"."downvotes"+"titleVotes"."verification" AS "score" 
+            FROM "titles" JOIN "titleVotes" ON "titles"."UUID" = "titleVotes"."UUID" 
+            WHERE "titles"."videoID" = ? 
+              AND "titles"."UUID" != ? 
+              AND "titleVotes"."locked" = 1`,
+            [videoID, UUID]);
 
         // Time to warn that there may be an issue
         if (lockedSubmission && currentSubmission.score - lockedSubmission.score > 2) {


### PR DESCRIPTION
- [x] I agree to license my contribution under AGPL-3.0-only with my contribution automatically being licensed under LGPL-3.0 additionally after 6 months

***

~~quick, absolutely untested fix (testing in production is the only valid way to test this)~~
i actually tested this locally now

Changes made:
- Don't send messages about an unlocked title having more votes than a locked one when the unlocked one is downvoted
- Take downvotes and verification into consideration when comparing titles in webhook code
- Send title score instead of just upvotes in the webhook message
- Send a message when a locked title is (attempted to be) downvoted
- Reformat SQL queries to (hopefully) be more readable