### PR TITLE
feat(routes/videoLabel): add ETag to responses

### DIFF
--- a/src/routes/getVideoLabel.ts
+++ b/src/routes/getVideoLabel.ts
@@ -5,6 +5,7 @@ import { SBRecord } from "../types/lib.model";
 import { ActionType, Category, DBSegment, Service, VideoID, VideoIDHash } from "../types/segments.model";
 import { Logger } from "../utils/logger";
 import { QueryCacher } from "../utils/queryCacher";
+import { getEtag } from "../middleware/etag";
 import { getService } from "../utils/getService";
 
 interface FullVideoSegment {
@@ -165,6 +166,10 @@ async function handleGetLabel(req: Request, res: Response): Promise<FullVideoSeg
         res.sendStatus(404);
         return false;
     }
+
+    await getEtag("videoLabel", (videoID as string), service)
+        .then(etag => res.set("ETag", etag))
+        .catch(() => null);
 
     if (hasStartSegment) {
         return segmentData;

--- a/src/routes/getVideoLabelByHash.ts
+++ b/src/routes/getVideoLabelByHash.ts
@@ -2,6 +2,7 @@ import { hashPrefixTester } from "../utils/hashPrefixTester";
 import { getLabelsByHash } from "./getVideoLabel";
 import { Request, Response } from "express";
 import { VideoIDHash, Service } from "../types/segments.model";
+import { getEtag } from "../middleware/etag";
 import { getService } from "../utils/getService";
 
 export async function getVideoLabelsByHash(req: Request, res: Response): Promise<Response> {
@@ -25,5 +26,11 @@ export async function getVideoLabelsByHash(req: Request, res: Response): Promise
         segments: data.segments,
         hasStartSegment: data.hasStartSegment
     }));
+
+
+    const hashKey = hashPrefix.length === 4 ? "videoLabelHash" : "videoLabelsLargerHash";
+    await getEtag(hashKey, hashPrefix, service)
+        .then(etag => res.set("ETag", etag))
+        .catch(() => null);
     return res.status(output.length === 0 ? 404 : 200).json(output);
 }


### PR DESCRIPTION
Adds the `ETag` header to the `/getVideoLabels` and the `/getVideoLabels:hash` routes, similarly to https://github.com/ajayyy/SponsorBlockServer/pull/533. This allows clients (e.g. [LibreTube](https://github.com/libre-tube/LibreTube/pull/7319)) to cache the responses reducing the amount of network traffic.

Ref: https://github.com/ajayyy/SponsorBlockServer/issues/576

This is marked as a draft, as I'm having trouble to get the server up and running to actually test the changes.

- [x] I agree to license my contribution under AGPL-3.0-only with my contribution automatically being licensed under LGPL-3.0 additionally after 6 months