### PR TITLE
Keep a history of warnings in the public database

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,15 +31,15 @@ module.exports = {
     },
     overrides: [
         {
-            files: ["src/**/*.ts"],
+            files: ["**/*.ts"],
 
             parserOptions: {
-                project: ["./tsconfig.json"],
+                project: ["./tsconfig.eslint.json"],
             },
 
             rules: {
-                "@typescript-eslint/no-misused-promises": "warn",
-                "@typescript-eslint/no-floating-promises" : "warn"
+                "@typescript-eslint/no-misused-promises": "error",
+                "@typescript-eslint/no-floating-promises" : "error"
             }
         },
     ],

--- a/ci.json
+++ b/ci.json
@@ -56,7 +56,6 @@
             ]
         }
     ],
-    "hoursAfterWarningExpires": 24,
     "rateLimit": {
         "vote": {
           "windowMs": 900000,

--- a/config.json.example
+++ b/config.json.example
@@ -25,8 +25,6 @@
     "webhooks": [],
     "categoryList": ["sponsor", "intro", "outro", "interaction", "selfpromo", "preview", "music_offtopic", "poi_highlight"], // List of supported categories any other category will be rejected
     "getTopUsersCacheTimeMinutes": 5, // cacheTime for getTopUsers result in minutes
-    "maxNumberOfActiveWarnings": 3, // Users with this number of warnings will be blocked until warnings expire
-    "hoursAfterWarningExpire": 24,
     "rateLimit": {
       "vote": {
         "windowMs": 900000, // 15 minutes

--- a/databases/_upgrade_sponsorTimes_45.sql
+++ b/databases/_upgrade_sponsorTimes_45.sql
@@ -1,0 +1,7 @@
+BEGIN TRANSACTION;
+
+ALTER TABLE "warnings" ADD "disableTime" INTEGER NULL;
+
+UPDATE "config" SET value = 45 WHERE key = 'version';
+
+COMMIT;

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,8 +37,6 @@ addDefaults(config, {
     },
     deArrowTypes: ["title", "thumbnail"],
     maxTitleLength: 110,
-    maxNumberOfActiveWarnings: 1,
-    hoursAfterWarningExpires: 16300000,
     adminUserID: "",
     discordCompletelyIncorrectReportWebhookURL: null,
     discordFirstTimeSubmissionsWebhookURL: null,

--- a/src/cronjob/downvoteSegmentArchiveJob.ts
+++ b/src/cronjob/downvoteSegmentArchiveJob.ts
@@ -3,7 +3,6 @@ import { CronJob } from "cron";
 import { config as serverConfig } from "../config";
 import { Logger } from "../utils/logger";
 import { db } from "../databases/databases";
-import { DBSegment } from "../types/segments.model";
 
 const jobConfig = serverConfig?.crons?.downvoteSegmentArchive;
 
@@ -14,18 +13,18 @@ export const archiveDownvoteSegment = async (dayLimit: number, voteLimit: number
     Logger.info(`DownvoteSegmentArchiveJob starts at ${timeNow}`);
     try {
     // insert into archive sponsorTime
-    await db.prepare(
-        "run",
-        `INSERT INTO "archivedSponsorTimes" 
-        SELECT * 
-        FROM "sponsorTimes" 
-        WHERE "votes" < ? AND (? - "timeSubmitted") > ?`,
-        [
-            voteLimit,
-            timeNow,
-            threshold
-        ]
-    ) as DBSegment[];
+        await db.prepare(
+            "run",
+            `INSERT INTO "archivedSponsorTimes" 
+             SELECT * 
+             FROM "sponsorTimes" 
+             WHERE "votes" < ? AND (? - "timeSubmitted") > ?`,
+            [
+                voteLimit,
+                timeNow,
+                threshold
+            ]
+        );
 
     } catch (err) {
         Logger.error("Execption when insert segment in archivedSponsorTimes");
@@ -35,15 +34,15 @@ export const archiveDownvoteSegment = async (dayLimit: number, voteLimit: number
 
     // remove from sponsorTime
     try {
-    await db.prepare(
-        "run",
-        'DELETE FROM "sponsorTimes" WHERE "votes" < ? AND (? - "timeSubmitted") > ?',
-        [
-            voteLimit,
-            timeNow,
-            threshold
-        ]
-    ) as DBSegment[];
+        await db.prepare(
+            "run",
+            'DELETE FROM "sponsorTimes" WHERE "votes" < ? AND (? - "timeSubmitted") > ?',
+            [
+                voteLimit,
+                timeNow,
+                threshold
+            ]
+        );
 
     } catch (err) {
         Logger.error("Execption when deleting segment in sponsorTimes");

--- a/src/databases/IDatabase.ts
+++ b/src/databases/IDatabase.ts
@@ -6,7 +6,10 @@ export interface QueryOption {
 export interface IDatabase {
     init(): Promise<void>;
 
-    prepare(type: QueryType, query: string, params?: any[], options?: QueryOption): Promise<any | any[] | void>;
+    prepare(type: "run", query: string, params?: any[], options?: QueryOption): Promise<void>;
+    prepare(type: "get", query: string, params?: any[], options?: QueryOption): Promise<any>;
+    prepare(type: "all", query: string, params?: any[], options?: QueryOption): Promise<any[]>;
+    prepare(type: QueryType, query: string, params?: any[], options?: QueryOption): Promise<any>;
 
     highLoad(): boolean;
 

--- a/src/databases/Postgres.ts
+++ b/src/databases/Postgres.ts
@@ -109,7 +109,7 @@ export class Postgres implements IDatabase {
         }
     }
 
-    async prepare(type: QueryType, query: string, params?: any[], options: QueryOption = {}): Promise<any[]> {
+    async prepare(type: QueryType, query: string, params?: any[], options: QueryOption = {}): Promise<any> {
         // Convert query to use numbered parameters
         let count = 1;
         for (let char = 0; char < query.length; char++) {

--- a/src/databases/Sqlite.ts
+++ b/src/databases/Sqlite.ts
@@ -13,7 +13,7 @@ export class Sqlite implements IDatabase {
     }
 
     // eslint-disable-next-line require-await
-    async prepare(type: QueryType, query: string, params: any[] = []): Promise<any[]> {
+    async prepare(type: QueryType, query: string, params: any[] = []): Promise<any> {
         // Logger.debug(`prepare (sqlite): type: ${type}, query: ${query}, params: ${params}`);
         const preparedQuery = this.db.prepare(Sqlite.processQuery(query));
 

--- a/src/routes/getVideoLabel.ts
+++ b/src/routes/getVideoLabel.ts
@@ -122,7 +122,7 @@ function chooseSegment<T extends DBSegment>(choices: T[]): FullVideoSegmentVideo
         return {
             segments: transformDBSegments(choices),
             hasStartSegment
-        }
+        };
     }
     // if locked, only choose from locked
     const locked = choices.filter((segment) => segment.locked);

--- a/src/routes/postWarning.ts
+++ b/src/routes/postWarning.ts
@@ -4,7 +4,6 @@ import { db } from "../databases/databases";
 import { isUserVIP } from "../utils/isUserVIP";
 import { getHashCache } from "../utils/getHashCache";
 import { HashedUserID, UserID } from "../types/user.model";
-import { config } from "../config";
 import { generateWarningDiscord, warningData, dispatchEvent } from "../utils/webhookUtils";
 import { WarningType } from "../types/warning.model";
 
@@ -16,12 +15,7 @@ type warningEntry = {
     reason: string
 }
 
-function checkExpiredWarning(warning: warningEntry): boolean {
-    const MILLISECONDS_IN_HOUR = 3600000;
-    const now = Date.now();
-    const expiry =  Math.floor(now - (config.hoursAfterWarningExpires * MILLISECONDS_IN_HOUR));
-    return warning.issueTime > expiry && !warning.enabled;
-}
+const MAX_EDIT_DELAY = 900000; // 15 mins
 
 const getUsername = (userID: HashedUserID) => db.prepare("get", `SELECT "userName" FROM "userNames" WHERE "userID" = ?`, [userID], { useReplica: true });
 
@@ -44,25 +38,25 @@ export async function postWarning(req: Request, res: Response): Promise<Response
 
     try {
         if (enabled) {
-            const previousWarning = await db.prepare("get", 'SELECT * FROM "warnings" WHERE "userID" = ? AND "issuerUserID" = ? AND "type" = ?', [userID, issuerUserID, type]) as warningEntry;
+            if (!reason) {
+                return res.status(400).json({ "message": "Missing warning reason" });
+            }
+            const previousWarning = await db.prepare("get", 'SELECT * FROM "warnings" WHERE "userID" = ? AND "type" = ? AND "enabled" = 1', [userID, type]) as warningEntry;
 
             if (!previousWarning) {
-                if (!reason) {
-                    return res.status(400).json({ "message": "Missing warning reason" });
-                }
                 await db.prepare(
                     "run",
                     'INSERT INTO "warnings" ("userID", "issueTime", "issuerUserID", "enabled", "reason", "type") VALUES (?, ?, ?, 1, ?, ?)',
                     [userID, issueTime, issuerUserID, reason, type]
                 );
                 resultStatus = "issued to";
-            // check if warning is still within issue time and warning is not enabled
-            } else if (checkExpiredWarning(previousWarning) ) {
+            // allow a warning to be edited by the same vip within 15 mins of issuing
+            } else if (issuerUserID === previousWarning.issuerUserID && (Date.now() - MAX_EDIT_DELAY) < previousWarning.issueTime) {
                 await db.prepare(
-                    "run", 'UPDATE "warnings" SET "enabled" = 1, "reason" = ? WHERE "userID" = ? AND "issueTime" = ?',
+                    "run", 'UPDATE "warnings" SET "reason" = ? WHERE "userID" = ? AND "issueTime" = ?',
                     [reason, userID, previousWarning.issueTime]
                 );
-                resultStatus = "re-enabled for";
+                resultStatus = "edited for";
             } else {
                 return res.sendStatus(409);
             }

--- a/src/routes/postWarning.ts
+++ b/src/routes/postWarning.ts
@@ -61,7 +61,7 @@ export async function postWarning(req: Request, res: Response): Promise<Response
                 return res.sendStatus(409);
             }
         } else {
-            await db.prepare("run", 'UPDATE "warnings" SET "enabled" = 0 WHERE "userID" = ? AND "type" = ?', [userID, type]);
+            await db.prepare("run", 'UPDATE "warnings" SET "enabled" = 0, "disableTime" = ? WHERE "userID" = ? AND "type" = ? AND "enabled" = 1', [issueTime, userID, type]);
             resultStatus = "removed from";
         }
 

--- a/src/routes/setUsername.ts
+++ b/src/routes/setUsername.ts
@@ -7,7 +7,7 @@ import { isUserBanned } from "../utils/checkBan";
 import { HashedUserID } from "../types/user.model";
 import { isRequestInvalid } from "../utils/requestValidator";
 
-function logUserNameChange(userID: string, newUserName: string, oldUserName: string, updatedByAdmin: boolean): Promise<Response>  {
+function logUserNameChange(userID: string, newUserName: string, oldUserName: string, updatedByAdmin: boolean): Promise<void>  {
     return privateDB.prepare("run",
         `INSERT INTO "userNameLogs"("userID", "newUserName", "oldUserName", "updatedByAdmin", "updatedAt") VALUES(?, ?, ?, ?, ?)`,
         [userID, newUserName, oldUserName, + updatedByAdmin, new Date().getTime()]

--- a/src/routes/voteOnSponsorTime.ts
+++ b/src/routes/voteOnSponsorTime.ts
@@ -379,14 +379,12 @@ export async function vote(ip: IPAddress, UUID: SegmentUUID, paramUserID: UserID
         return { status: 400 };
     }
 
-    const MILLISECONDS_IN_HOUR = 3600000;
-    const now = Date.now();
-    const warnings = (await db.prepare("all", `SELECT "reason" FROM warnings WHERE "userID" = ? AND "issueTime" > ? AND enabled = 1  AND type = 0`,
-        [nonAnonUserID, Math.floor(now - (config.hoursAfterWarningExpires * MILLISECONDS_IN_HOUR))],
+    const warning = (await db.prepare("get", `SELECT "reason" FROM warnings WHERE "userID" = ? AND enabled = 1  AND type = 0`,
+        [nonAnonUserID],
     ));
 
-    if (warnings.length >= config.maxNumberOfActiveWarnings) {
-        const warningReason = warnings[0]?.reason;
+    if (warning != null) {
+        const warningReason = warning.reason;
         lock.unlock();
         return { status: 403, message: "Vote rejected due to a tip from a moderator. This means that we noticed you were making some common mistakes that are not malicious, and we just want to clarify the rules. " +
                 "Could you please send a message in Discord or Matrix so we can further help you?" +

--- a/src/types/config.model.ts
+++ b/src/types/config.model.ts
@@ -109,8 +109,6 @@ export interface SBSConfig {
     categorySupport: Record<string, string[]>;
     maxTitleLength: number;
     getTopUsersCacheTimeMinutes: number;
-    maxNumberOfActiveWarnings: number;
-    hoursAfterWarningExpires: number;
     rateLimit: {
         vote: RateLimitConfig;
         view: RateLimitConfig;

--- a/test.json
+++ b/test.json
@@ -50,7 +50,6 @@
             ]
         }
     ],
-    "hoursAfterWarningExpires": 24,
     "rateLimit": {
         "vote": {
           "windowMs": 900000,

--- a/test/cases/getUserID.ts
+++ b/test/cases/getUserID.ts
@@ -73,11 +73,11 @@ describe("getUserID", () => {
         )
     );
 
-    it("Should be able to get multiple fuzzy user info from middle", () => {
+    it("Should be able to get multiple fuzzy user info from middle", () =>
         validateSearch("user",
             [users["fuzzy_1"], users["fuzzy_2"], users["specific_1"]]
-        );
-    });
+        )
+    );
 
     it("Should be able to get with fuzzy public ID", () => {
         const userID = users["public_1"].pubID.substring(0,60);

--- a/test/cases/getUserInfo.ts
+++ b/test/cases/getUserInfo.ts
@@ -81,19 +81,19 @@ describe("getUserInfo", () => {
 
         // warnings & bans
         // warn-0
-        insertWarning(db, users["warn-0"].pubID, { reason: "warning0-0", issueTime: 10 });
+        await insertWarning(db, users["warn-0"].pubID, { reason: "warning0-0", issueTime: 10 });
         // warn-1
-        insertWarning(db, users["warn-1"].pubID, { reason: "warning1-0", issueTime: 20 });
-        insertWarning(db, users["warn-1"].pubID, { reason: "warning1-1", issueTime: 30 });
+        await insertWarning(db, users["warn-1"].pubID, { reason: "warning1-0", issueTime: 20 });
+        await insertWarning(db, users["warn-1"].pubID, { reason: "warning1-1", issueTime: 30 });
         // warn -2
-        insertWarning(db, users["warn-2"].pubID, { reason: "warning2-0", issueTime: 40, enabled: false });
+        await insertWarning(db, users["warn-2"].pubID, { reason: "warning2-0", issueTime: 40, enabled: false });
         // warn-3
-        insertWarning(db, users["warn-3"].pubID, { reason: "warning3-0", issueTime: 50 });
-        insertWarning(db, users["warn-3"].pubID, { reason: "warning3-1", issueTime: 60, enabled: false });
+        await insertWarning(db, users["warn-3"].pubID, { reason: "warning3-0", issueTime: 50 });
+        await insertWarning(db, users["warn-3"].pubID, { reason: "warning3-1", issueTime: 60, enabled: false });
 
         // ban-
-        insertBan(db, users["ban-1"].pubID);
-        insertBan(db, users["ban-2"].pubID);
+        await insertBan(db, users["ban-1"].pubID);
+        await insertBan(db, users["ban-2"].pubID);
     });
 
     it("Should be able to get a 200", () => statusTest(200, { userID: users["n-1"].privID }));

--- a/test/cases/getViewsForUser.ts
+++ b/test/cases/getViewsForUser.ts
@@ -33,11 +33,11 @@ const checkUserViews = (user: User) =>
         });
 
 describe("getViewsForUser", function() {
-    before(() => {
+    before(async () => {
         // add views for users
-        insertSegment(db, { userID: users["u-1"].pubID, views: users["u-1"].info.views1 });
-        insertSegment(db, { userID: users["u-1"].pubID, views: users["u-1"].info.views2 });
-        insertSegment(db, { userID: users["u-2"].pubID, views: users["u-2"].info.views });
+        await insertSegment(db, { userID: users["u-1"].pubID, views: users["u-1"].info.views1 });
+        await insertSegment(db, { userID: users["u-1"].pubID, views: users["u-1"].info.views2 });
+        await insertSegment(db, { userID: users["u-2"].pubID, views: users["u-2"].info.views });
     });
     it("Should get back views for user one", () =>
         checkUserViews(users["u-1"])

--- a/test/cases/postBranding.ts
+++ b/test/cases/postBranding.ts
@@ -15,7 +15,6 @@ describe("postBranding", () => {
     const userID5 = `PostBrandingUser5${".".repeat(16)}`;
     const userID6 = `PostBrandingUser6${".".repeat(16)}`;
     const userID7 = `PostBrandingUser7${".".repeat(16)}`;
-    const userID8 = `PostBrandingUser8${".".repeat(16)}`;
     const bannedUser = `BannedPostBrandingUser${".".repeat(16)}`;
 
 

--- a/test/cases/postSkipSegments.ts
+++ b/test/cases/postSkipSegments.ts
@@ -50,12 +50,12 @@ describe("postSkipSegments", () => {
     const queryDatabaseActionType = (videoID: string) => db.prepare("get", `SELECT "startTime", "endTime", "locked", "category", "actionType" FROM "sponsorTimes" WHERE "videoID" = ?`, [videoID]);
     const queryDatabaseVideoInfo = (videoID: string) => db.prepare("get", `SELECT * FROM "videoInfo" WHERE "videoID" = ?`, [videoID]);
 
-    before(() => {
+    before(async () => {
         const insertSponsorTimeQuery = 'INSERT INTO "sponsorTimes" ("videoID", "startTime", "endTime", "votes", "UUID", "userID", "timeSubmitted", views, category, "actionType", "videoDuration", "shadowHidden", "hashedVideoID") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
-        db.prepare("run", insertSponsorTimeQuery, ["full_video_segment", 0, 0, 0, "full-video-uuid-0", submitUserTwoHash, 0, 0, "sponsor", "full", 0, 0, "full_video_segment"]);
+        await db.prepare("run", insertSponsorTimeQuery, ["full_video_segment", 0, 0, 0, "full-video-uuid-0", submitUserTwoHash, 0, 0, "sponsor", "full", 0, 0, "full_video_segment"]);
 
         const insertVipUserQuery = 'INSERT INTO "vipUsers" ("userID") VALUES (?)';
-        db.prepare("run", insertVipUserQuery, [getHash(submitVIPuser)]);
+        await db.prepare("run", insertVipUserQuery, [getHash(submitVIPuser)]);
     });
 
     it("Should be able to submit a single time (Params method)", (done) => {

--- a/test/cases/postSkipSegmentsAutomod.ts
+++ b/test/cases/postSkipSegmentsAutomod.ts
@@ -19,11 +19,11 @@ describe("postSkipSegments - Automod 80%", () => {
 
     const queryDatabaseCategory = (videoID: string) => db.prepare("all", `SELECT "startTime", "endTime", "category" FROM "sponsorTimes" WHERE "videoID" = ? and "votes" > -1`, [videoID]);
 
-    before(() => {
+    before(async () => {
         const insertSponsorTimeQuery = 'INSERT INTO "sponsorTimes" ("videoID", "startTime", "endTime", "votes", "UUID", "userID", "timeSubmitted", views, category, "actionType", "videoDuration", "shadowHidden", "hashedVideoID") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
-        db.prepare("run", insertSponsorTimeQuery, [over80VideoID, 0, 1000, 0, "80percent-uuid-0", userIDHash, 0, 0, "interaction", "skip", 0, 0, over80VideoID]);
-        db.prepare("run", insertSponsorTimeQuery, [over80VideoID, 1001, 1005, 0, "80percent-uuid-1", userIDHash, 0, 0, "interaction", "skip", 0, 0, over80VideoID]);
-        db.prepare("run", insertSponsorTimeQuery, [over80VideoID, 0, 5000, -2, "80percent-uuid-2", userIDHash, 0, 0, "interaction", "skip", 0, 0, over80VideoID]);
+        await db.prepare("run", insertSponsorTimeQuery, [over80VideoID, 0, 1000, 0, "80percent-uuid-0", userIDHash, 0, 0, "interaction", "skip", 0, 0, over80VideoID]);
+        await db.prepare("run", insertSponsorTimeQuery, [over80VideoID, 1001, 1005, 0, "80percent-uuid-1", userIDHash, 0, 0, "interaction", "skip", 0, 0, over80VideoID]);
+        await db.prepare("run", insertSponsorTimeQuery, [over80VideoID, 0, 5000, -2, "80percent-uuid-2", userIDHash, 0, 0, "interaction", "skip", 0, 0, over80VideoID]);
     });
 
     it("Should allow multiple times if total is under 80% of video (JSON method)", (done) => {

--- a/test/cases/postSkipSegmentsDuration.ts
+++ b/test/cases/postSkipSegmentsDuration.ts
@@ -21,10 +21,10 @@ describe("postSkipSegments - duration", () => {
 
     const queryDatabaseDuration = (videoID: string) => db.prepare("get", `SELECT "startTime", "endTime", "locked", "category", "videoDuration" FROM "sponsorTimes" WHERE "videoID" = ?`, [videoID]);
 
-    before(() => {
+    before(async () => {
         const insertSponsorTimeQuery = 'INSERT INTO "sponsorTimes" ("videoID", "startTime", "endTime", "votes", "UUID", "userID", "timeSubmitted", views, category, "actionType", "videoDuration", "shadowHidden", "hashedVideoID") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
-        db.prepare("run", insertSponsorTimeQuery, ["full_video_duration_segment", 0, 0, 0, "full-video-duration-uuid-0", userIDTwo, 0, 0, "sponsor", "full", 123, 0, "full_video_duration_segment"]);
-        db.prepare("run", insertSponsorTimeQuery, ["full_video_duration_segment", 25, 30, 0, "full-video-duration-uuid-1", userIDTwo, 0, 0, "sponsor", "skip", 123, 0, "full_video_duration_segment"]);
+        await db.prepare("run", insertSponsorTimeQuery, ["full_video_duration_segment", 0, 0, 0, "full-video-duration-uuid-0", userIDTwo, 0, 0, "sponsor", "full", 123, 0, "full_video_duration_segment"]);
+        await db.prepare("run", insertSponsorTimeQuery, ["full_video_duration_segment", 25, 30, 0, "full-video-duration-uuid-1", userIDTwo, 0, 0, "sponsor", "skip", 123, 0, "full_video_duration_segment"]);
     });
 
     it("Should be able to submit a single time with a precise duration close to the one from the YouTube API (JSON method)", (done) => {

--- a/test/cases/postSkipSegmentsFeatures.ts
+++ b/test/cases/postSkipSegmentsFeatures.ts
@@ -21,17 +21,17 @@ describe("postSkipSegments Features - Chapters", () => {
         };
     }
 
-    before(() => {
+    before(async () => {
         const submitNumberOfTimes = 10;
         const submitUser_reputationHash = getHash(submitUser_reputation);
         const insertSponsorTimeQuery = 'INSERT INTO "sponsorTimes" ("videoID", "startTime", "endTime", "votes", "locked", "UUID", "userID", "timeSubmitted", views, category, "actionType", "shadowHidden") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
         for (let i = 0; i < submitNumberOfTimes; i++) {
             const uuid = `post_reputation_uuid-${i}`;
             const videoID = `post_reputation_video-${i}`;
-            db.prepare("run", insertSponsorTimeQuery, [videoID, 1, 11, 5, 1, uuid, submitUser_reputationHash, 1597240000000, 50, "sponsor", "skip", 0]);
+            await db.prepare("run", insertSponsorTimeQuery, [videoID, 1, 11, 5, 1, uuid, submitUser_reputationHash, 1597240000000, 50, "sponsor", "skip", 0]);
         }
         // user feature
-        db.prepare("run", `INSERT INTO "userFeatures" ("userID", "feature", "issuerUserID", "timeSubmitted") VALUES(?, ?, ?, ?)`, [getHash(submitUser_feature), Feature.ChapterSubmitter, "generic-VIP", 0]);
+        await db.prepare("run", `INSERT INTO "userFeatures" ("userID", "feature", "issuerUserID", "timeSubmitted") VALUES(?, ?, ?, ?)`, [getHash(submitUser_feature), Feature.ChapterSubmitter, "generic-VIP", 0]);
     });
 
     it("Should be able to submit a single chapter due to reputation (JSON method)", (done) => {

--- a/test/cases/postSkipSegmentsLocked.ts
+++ b/test/cases/postSkipSegmentsLocked.ts
@@ -9,10 +9,10 @@ describe("postSkipSegments - LockedVideos", () => {
     const videoID = "lockedVideo";
     const userID = userIDOne;
 
-    before(() => {
+    before(async () => {
         const insertLockCategoriesQuery = `INSERT INTO "lockCategories" ("userID", "videoID", "category", "reason") VALUES(?, ?, ?, ?)`;
-        db.prepare("run", insertLockCategoriesQuery, [getHash(VIPLockUser), videoID, "sponsor", "Custom Reason"]);
-        db.prepare("run", insertLockCategoriesQuery, [getHash(VIPLockUser), videoID, "intro", ""]);
+        await db.prepare("run", insertLockCategoriesQuery, [getHash(VIPLockUser), videoID, "sponsor", "Custom Reason"]);
+        await db.prepare("run", insertLockCategoriesQuery, [getHash(VIPLockUser), videoID, "intro", ""]);
     });
 
     it("Should return 403 and custom reason for submiting in lockedCategory", (done) => {

--- a/test/cases/postSkipSegmentsShadowban.ts
+++ b/test/cases/postSkipSegmentsShadowban.ts
@@ -19,8 +19,8 @@ describe("postSkipSegments - shadowban", () => {
 
     const queryDatabaseShadowhidden = (videoID: string) => db.prepare("get", `SELECT "startTime", "endTime", "shadowHidden", "userID" FROM "sponsorTimes" WHERE "videoID" = ?`, [videoID]);
 
-    before(() => {
-        db.prepare("run", `INSERT INTO "shadowBannedUsers" ("userID") VALUES(?)`, [banUser01Hash]);
+    before(async () => {
+        await db.prepare("run", `INSERT INTO "shadowBannedUsers" ("userID") VALUES(?)`, [banUser01Hash]);
     });
 
     it("Should automatically shadowban segments if user is banned", (done) => {

--- a/test/cases/postSkipSegmentsUserAgent.ts
+++ b/test/cases/postSkipSegmentsUserAgent.ts
@@ -21,10 +21,10 @@ describe("postSkipSegments - userAgent", () => {
     };
     const dbFormatSegment = convertSingleToDBFormat(segment);
 
-    before(() => {
+    before(async () => {
         const insertLockCategoriesQuery = `INSERT INTO "lockCategories" ("userID", "videoID", "category", "reason") VALUES(?, ?, ?, ?)`;
-        db.prepare("run", insertLockCategoriesQuery, [getHash(VIPLockUser), videoID, "sponsor", "Custom Reason"]);
-        db.prepare("run", insertLockCategoriesQuery, [getHash(VIPLockUser), videoID, "intro", ""]);
+        await db.prepare("run", insertLockCategoriesQuery, [getHash(VIPLockUser), videoID, "sponsor", "Custom Reason"]);
+        await db.prepare("run", insertLockCategoriesQuery, [getHash(VIPLockUser), videoID, "intro", ""]);
     });
 
     it("Should be able to submit with empty user-agent", (done) => {

--- a/test/cases/postSkipSegmentsWarnings.ts
+++ b/test/cases/postSkipSegmentsWarnings.ts
@@ -23,7 +23,7 @@ describe("postSkipSegments Warnings", () => {
         data
     });
 
-    before(() => {
+    before(async () => {
         const now = Date.now();
 
         const warnVip01Hash = getHash("postSkipSegmentsWarnVIP");
@@ -34,14 +34,14 @@ describe("postSkipSegments Warnings", () => {
 
         const insertWarningQuery = 'INSERT INTO warnings ("userID", "issuerUserID", "enabled", "reason", "issueTime") VALUES(?, ?, ?, ?, ?)';
         // User 1 | 1 active | custom reason
-        db.prepare("run", insertWarningQuery, [warnUser01Hash, warnVip01Hash, 1, reason01, now]);
+        await db.prepare("run", insertWarningQuery, [warnUser01Hash, warnVip01Hash, 1, reason01, now]);
         // User 2 | 1 inactive | default reason
-        db.prepare("run", insertWarningQuery, [warnUser02Hash, warnVip01Hash, 0, reason02, now]);
+        await db.prepare("run", insertWarningQuery, [warnUser02Hash, warnVip01Hash, 0, reason02, now]);
         // User 3 | 1 inactive, 1 active | different reasons
-        db.prepare("run", insertWarningQuery, [warnUser03Hash, warnVip01Hash, 0, reason01, now]);
-        db.prepare("run", insertWarningQuery, [warnUser03Hash, warnVip01Hash, 1, reason03, now]);
+        await db.prepare("run", insertWarningQuery, [warnUser03Hash, warnVip01Hash, 0, reason01, now]);
+        await db.prepare("run", insertWarningQuery, [warnUser03Hash, warnVip01Hash, 1, reason03, now+1]);
         // User 4 | 1 active | default reason
-        db.prepare("run", insertWarningQuery, [warnUser04Hash, warnVip01Hash, 1, reason02, now]);
+        await db.prepare("run", insertWarningQuery, [warnUser04Hash, warnVip01Hash, 1, reason02, now]);
     });
 
     it("Should be rejected with custom message if user has active warnings", (done) => {

--- a/test/cases/postSkipSegmentsWarnings.ts
+++ b/test/cases/postSkipSegmentsWarnings.ts
@@ -1,19 +1,11 @@
-import { getHash } from "../../src/utils/getHash";
 import { db } from "../../src/databases/databases";
 import assert from "assert";
 import { client } from "../utils/httpClient";
+import { usersForSuite } from "../utils/randomUsers";
 
 describe("postSkipSegments Warnings", () => {
     // Constant and helpers
-    const warnUser01 = "warn-user01";
-    const warnUser01Hash = getHash(warnUser01);
-    const warnUser02 = "warn-user02";
-    const warnUser02Hash = getHash(warnUser02);
-    const warnUser03 = "warn-user03";
-    const warnUser03Hash = getHash(warnUser03);
-    const warnUser04 = "warn-user04";
-    const warnUser04Hash = getHash(warnUser04);
-
+    const users = usersForSuite("postSkipSegmentsWarnings");
     const warnVideoID = "postSkipSegments-warn-video";
 
     const endpoint = "/api/skipSegments";
@@ -26,107 +18,89 @@ describe("postSkipSegments Warnings", () => {
     before(async () => {
         const now = Date.now();
 
-        const warnVip01Hash = getHash("postSkipSegmentsWarnVIP");
-
         const reason01 = "Reason01";
         const reason02 = "";
         const reason03 = "Reason03";
 
         const insertWarningQuery = 'INSERT INTO warnings ("userID", "issuerUserID", "enabled", "reason", "issueTime") VALUES(?, ?, ?, ?, ?)';
         // User 1 | 1 active | custom reason
-        await db.prepare("run", insertWarningQuery, [warnUser01Hash, warnVip01Hash, 1, reason01, now]);
+        await db.prepare("run", insertWarningQuery, [users.u01.public, users.vip01.public, 1, reason01, now]);
         // User 2 | 1 inactive | default reason
-        await db.prepare("run", insertWarningQuery, [warnUser02Hash, warnVip01Hash, 0, reason02, now]);
+        await db.prepare("run", insertWarningQuery, [users.u02.public, users.vip01.public, 0, reason02, now]);
         // User 3 | 1 inactive, 1 active | different reasons
-        await db.prepare("run", insertWarningQuery, [warnUser03Hash, warnVip01Hash, 0, reason01, now]);
-        await db.prepare("run", insertWarningQuery, [warnUser03Hash, warnVip01Hash, 1, reason03, now+1]);
+        await db.prepare("run", insertWarningQuery, [users.u03.public, users.vip01.public, 0, reason01, now]);
+        await db.prepare("run", insertWarningQuery, [users.u03.public, users.vip01.public, 1, reason03, now+1]);
         // User 4 | 1 active | default reason
-        await db.prepare("run", insertWarningQuery, [warnUser04Hash, warnVip01Hash, 1, reason02, now]);
+        await db.prepare("run", insertWarningQuery, [users.u04.public, users.vip01.public, 1, reason02, now]);
     });
 
-    it("Should be rejected with custom message if user has active warnings", (done) => {
-        postSkipSegmentJSON({
-            userID: warnUser01,
+    it("Should be rejected with custom message if user has active warnings", async () => {
+        const res = await postSkipSegmentJSON({
+            userID: users.u01.private,
             videoID: warnVideoID,
             segments: [{
                 segment: [0, 10],
                 category: "sponsor",
             }],
-        })
-            .then(res => {
-                assert.strictEqual(res.status, 403);
-                const errorMessage = res.data;
-                const reason = "Reason01";
-                const expected = "Submission rejected due to a tip from a moderator. This means that we noticed you were making some common mistakes"
-                + " that are not malicious, and we just want to clarify the rules. "
-                + "Could you please send a message in discord.gg/SponsorBlock or matrix.to/#/#sponsor:ajay.app so we can further help you? "
-                + `Your userID is ${warnUser01Hash}.\n\nTip message: '${reason}'`;
+        });
+        assert.strictEqual(res.status, 403);
+        const errorMessage = res.data;
+        const reason = "Reason01";
+        const expected = "Submission rejected due to a tip from a moderator. This means that we noticed you were making some common mistakes"
+        + " that are not malicious, and we just want to clarify the rules. "
+        + "Could you please send a message in discord.gg/SponsorBlock or matrix.to/#/#sponsor:ajay.app so we can further help you? "
+        + `Your userID is ${users.u01.public}.\n\nTip message: '${reason}'`;
 
-                assert.strictEqual(errorMessage, expected);
-                done();
-            })
-            .catch(err => done(err));
+        assert.strictEqual(errorMessage, expected);
     });
 
-    it("Should be accepted if user has inactive warning", (done) => {
-        postSkipSegmentJSON({
-            userID: warnUser02,
+    it("Should be accepted if user has inactive warning", async () => {
+        const res = await postSkipSegmentJSON({
+            userID: users.u02.private,
             videoID: warnVideoID,
             segments: [{
                 segment: [50, 60],
                 category: "sponsor",
             }],
-        })
-            .then(res => {
-                assert.ok(res.status === 200, `Status code was ${res.status} ${res.data}`);
-                done();
-            })
-            .catch(err => done(err));
+        });
+        assert.ok(res.status === 200, `Status code was ${res.status} ${res.data}`);
     });
 
-    it("Should be rejected with custom message if user has active warnings, even if has one inactive warning, should use current message", (done) => {
-        postSkipSegmentJSON({
-            userID: warnUser03,
+    it("Should be rejected with custom message if user has active warnings, even if has one inactive warning, should use current message", async () => {
+        const res = await postSkipSegmentJSON({
+            userID: users.u03.private,
             videoID: warnVideoID,
             segments: [{
                 segment: [10, 20],
                 category: "sponsor",
             }],
-        })
-            .then(res => {
-                assert.strictEqual(res.status, 403);
-                const errorMessage = res.data;
-                const reason = "Reason03";
-                const expected = "Submission rejected due to a tip from a moderator. This means that we noticed you were making some common mistakes"
-                + " that are not malicious, and we just want to clarify the rules. "
-                + "Could you please send a message in discord.gg/SponsorBlock or matrix.to/#/#sponsor:ajay.app so we can further help you? "
-                + `Your userID is ${warnUser03Hash}.\n\nTip message: '${reason}'`;
+        });
+        assert.strictEqual(res.status, 403);
+        const errorMessage = res.data;
+        const reason = "Reason03";
+        const expected = "Submission rejected due to a tip from a moderator. This means that we noticed you were making some common mistakes"
+        + " that are not malicious, and we just want to clarify the rules. "
+        + "Could you please send a message in discord.gg/SponsorBlock or matrix.to/#/#sponsor:ajay.app so we can further help you? "
+        + `Your userID is ${users.u03.public}.\n\nTip message: '${reason}'`;
 
-                assert.strictEqual(errorMessage, expected);
-                done();
-            })
-            .catch(err => done(err));
+        assert.strictEqual(errorMessage, expected);
     });
 
-    it("Should be rejected with default message if user has active warning", (done) => {
-        postSkipSegmentJSON({
-            userID: warnUser04,
+    it("Should be rejected with default message if user has active warning", async () => {
+        const res = await postSkipSegmentJSON({
+            userID: users.u04.private,
             videoID: warnVideoID,
             segments: [{
                 segment: [0, 10],
                 category: "sponsor",
             }],
-        })
-            .then(res => {
-                assert.strictEqual(res.status, 403);
-                const errorMessage = res.data;
-                const expected = "Submission rejected due to a tip from a moderator. This means that we noticed you were making some common mistakes"
-                + " that are not malicious, and we just want to clarify the rules. "
-                + "Could you please send a message in discord.gg/SponsorBlock or matrix.to/#/#sponsor:ajay.app so we can further help you? "
-                + `Your userID is ${warnUser04Hash}.`;
-                assert.strictEqual(errorMessage, expected);
-                done();
-            })
-            .catch(err => done(err));
+        });
+        assert.strictEqual(res.status, 403);
+        const errorMessage = res.data;
+        const expected = "Submission rejected due to a tip from a moderator. This means that we noticed you were making some common mistakes"
+        + " that are not malicious, and we just want to clarify the rules. "
+        + "Could you please send a message in discord.gg/SponsorBlock or matrix.to/#/#sponsor:ajay.app so we can further help you? "
+        + `Your userID is ${users.u04.public}.`;
+        assert.strictEqual(errorMessage, expected);
     });
 });

--- a/test/cases/postWarning.ts
+++ b/test/cases/postWarning.ts
@@ -7,25 +7,65 @@ import { client } from "../utils/httpClient";
 describe("postWarning", () => {
     // constants
     const endpoint = "/api/warnUser";
-    const getWarning = (userID: string, type = 0) => db.prepare("get", `SELECT "userID", "issueTime", "issuerUserID", enabled, "reason" FROM warnings WHERE "userID" = ? AND "type" = ?`, [userID, type]);
+    const getWarning = (userID: string, type = 0) => db.prepare("all", `SELECT "userID", "issueTime", "issuerUserID", enabled, "reason" FROM warnings WHERE "userID" = ? AND "type" = ? ORDER BY "issueTime" ASC`, [userID, type]);
 
-    const warneduserOneID = "warning-0";
-    const warnedUserTwoID = "warning-1";
-    const warnedUserOnePublicID = getHash(warneduserOneID);
-    const warnedUserTwoPublicID = getHash(warnedUserTwoID);
-    const warningVipOne = "warning-vip-1";
-    const warningVipTwo = "warning-vip-2";
+    const userID0 = "warning-0";
+    const userID1 = "warning-1";
+    const userID2 = "warning-2";
+    const userID3 = "warning-3";
+    const userID4 = "warning-4";
+    const userID5 = "warning-5";
+    const userID6 = "warning-6";
+    const userID7 = "warning-7";
+    const userID8 = "warning-8";
+    const userID9 = "warning-9";
+    const userID10 = "warning-10";
+    const userID11 = "warning-11";
+    const userID12 = "warning-12";
+    const userID13 = "warning-13";
+    const publicUserID0 = getHash(userID0);
+    const publicUserID1 = getHash(userID1);
+    const publicUserID2 = getHash(userID2);
+    const publicUserID3 = getHash(userID3);
+    const publicUserID4 = getHash(userID4);
+    const publicUserID5 = getHash(userID5);
+    const publicUserID6 = getHash(userID6);
+    const publicUserID7 = getHash(userID7);
+    const publicUserID8 = getHash(userID8);
+    const publicUserID9 = getHash(userID9);
+    const publicUserID10 = getHash(userID10);
+    const publicUserID11 = getHash(userID11);
+    const publicUserID12 = getHash(userID12);
+    const publicUserID13 = getHash(userID13);
+    const vipID1 = "warning-vip-1";
+    const vipID2 = "warning-vip-2";
+    const publicVipID1 = getHash(vipID1);
+    const publicVipID2 = getHash(vipID2);
     const nonVipUser = "warning-non-vip";
 
     before(async () => {
-        await db.prepare("run", `INSERT INTO "vipUsers" ("userID") VALUES (?)`, [getHash(warningVipOne)]);
-        await db.prepare("run", `INSERT INTO "vipUsers" ("userID") VALUES (?)`, [getHash(warningVipTwo)]);
+        const insertWarningQuery = 'INSERT INTO warnings ("userID", "issuerUserID", "enabled", "reason", "issueTime") VALUES(?, ?, ?, ?, ?)';
+        const HOUR = 60 * 60 * 1000;
+
+        await db.prepare("run", `INSERT INTO "vipUsers" ("userID") VALUES (?)`, [publicVipID1]);
+        await db.prepare("run", `INSERT INTO "vipUsers" ("userID") VALUES (?)`, [publicVipID2]);
+
+        await db.prepare("run", insertWarningQuery, [publicUserID1, publicVipID1, 1, "warn reason 1", (Date.now() - 24 * HOUR)]); // 24 hours is much past the edit deadline
+        await db.prepare("run", insertWarningQuery, [publicUserID2, publicVipID1, 1, "warn reason 2", (Date.now() - 24 * HOUR)]);
+        await db.prepare("run", insertWarningQuery, [publicUserID3, publicVipID1, 1, "warn reason 3", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [publicUserID4, publicVipID1, 1, "warn reason 4", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [publicUserID6, publicVipID1, 1, "warn reason 6", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [publicUserID9, publicVipID1, 0, "warn reason 9", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [publicUserID10, publicVipID1, 1, "warn reason 10", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [publicUserID11, publicVipID1, 1, "warn reason 11", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [publicUserID12, publicVipID1, 0, "warn reason 12", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [publicUserID13, publicVipID1, 0, "warn reason 13", Date.now()]);
     });
 
     it("Should be able to create warning if vip (exp 200)", (done) => {
         const json = {
-            issuerUserID: warningVipOne,
-            userID: warnedUserOnePublicID,
+            issuerUserID: vipID1,
+            userID: publicUserID0,
             reason: "warning-reason-0"
         };
         client.post(endpoint, json)
@@ -37,16 +77,18 @@ describe("postWarning", () => {
                     issuerUserID: getHash(json.issuerUserID),
                     reason: json.reason,
                 };
-                assert.ok(partialDeepEquals(row, expected));
+                assert.equal(row.length, 1);
+                assert.ok(partialDeepEquals(row[0], expected));
                 done();
             })
             .catch(err => done(err));
     });
 
-    it("Should be not be able to create a duplicate warning if vip", (done) => {
+    it("Should be not be able to edit a warning if past deadline and same vip", (done) => {
         const json = {
-            issuerUserID: warningVipOne,
-            userID: warnedUserOnePublicID,
+            issuerUserID: vipID1,
+            userID: publicUserID1,
+            reason: "edited reason 1",
         };
 
         client.post(endpoint, json)
@@ -55,18 +97,41 @@ describe("postWarning", () => {
                 const row = await getWarning(json.userID);
                 const expected = {
                     enabled: 1,
-                    issuerUserID: getHash(json.issuerUserID),
+                    issuerUserID: publicVipID1,
                 };
-                assert.ok(partialDeepEquals(row, expected));
+                assert.equal(row.length, 1);
+                assert.ok(partialDeepEquals(row[0], expected));
                 done();
             })
             .catch(err => done(err));
     });
 
-    it("Should be able to remove warning if vip", (done) => {
+    it("Should be not be able to edit a warning if past deadline and different vip", (done) => {
         const json = {
-            issuerUserID: warningVipOne,
-            userID: warnedUserOnePublicID,
+            issuerUserID: vipID2,
+            userID: publicUserID2,
+            reason: "edited reason 2",
+        };
+
+        client.post(endpoint, json)
+            .then(async res => {
+                assert.strictEqual(res.status, 409);
+                const row = await getWarning(json.userID);
+                const expected = {
+                    enabled: 1,
+                    issuerUserID: publicVipID1,
+                };
+                assert.equal(row.length, 1);
+                assert.ok(partialDeepEquals(row[0], expected));
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it("Should be able to remove warning if same vip as issuer", (done) => {
+        const json = {
+            issuerUserID: vipID1,
+            userID: publicUserID3,
             enabled: false
         };
 
@@ -77,7 +142,29 @@ describe("postWarning", () => {
                 const expected = {
                     enabled: 0
                 };
-                assert.ok(partialDeepEquals(row, expected));
+                assert.equal(row.length, 1);
+                assert.ok(partialDeepEquals(row[0], expected));
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it("Should be able to remove warning if not the same vip as issuer", (done) => {
+        const json = {
+            issuerUserID: vipID2,
+            userID: publicUserID4,
+            enabled: false
+        };
+
+        client.post(endpoint, json)
+            .then(async res => {
+                assert.strictEqual(res.status, 200);
+                const row = await getWarning(json.userID);
+                const expected = {
+                    enabled: 0
+                };
+                assert.equal(row.length, 1);
+                assert.ok(partialDeepEquals(row[0], expected));
                 done();
             })
             .catch(err => done(err));
@@ -86,7 +173,8 @@ describe("postWarning", () => {
     it("Should not be able to create warning if not vip (exp 403)", (done) => {
         const json = {
             issuerUserID: nonVipUser,
-            userID: warnedUserOnePublicID,
+            userID: publicUserID5,
+            reason: "warn reason 5",
         };
 
         client.post(endpoint, json)
@@ -106,40 +194,21 @@ describe("postWarning", () => {
             .catch(err => done(err));
     });
 
-    it("Should re-enable disabled warning", (done) => {
-        const json = {
-            issuerUserID: warningVipOne,
-            userID: warnedUserOnePublicID,
-            enabled: true
-        };
-
-        client.post(endpoint, json)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const data = await getWarning(json.userID);
-                const expected = {
-                    enabled: 1
-                };
-                assert.ok(partialDeepEquals(data, expected));
-                done();
-            })
-            .catch(err => done(err));
-    });
-
     it("Should be able to remove your own warning", (done) => {
         const json = {
-            userID: warneduserOneID,
+            userID: userID6,
             enabled: false
         };
 
         client.post(endpoint, json)
             .then(async res => {
                 assert.strictEqual(res.status, 200);
-                const data = await getWarning(warnedUserOnePublicID);
+                const row = await getWarning(publicUserID6);
                 const expected = {
                     enabled: 0
                 };
-                assert.ok(partialDeepEquals(data, expected));
+                assert.equal(row.length, 1);
+                assert.ok(partialDeepEquals(row[0], expected));
                 done();
             })
             .catch(err => done(err));
@@ -147,18 +216,16 @@ describe("postWarning", () => {
 
     it("Should not be able to add your own warning", (done) => {
         const json = {
-            userID: warneduserOneID,
-            enabled: true
+            userID: userID7,
+            enabled: true,
+            reason: "warn reason 7",
         };
 
         client.post(endpoint, json)
             .then(async res => {
                 assert.strictEqual(res.status, 403);
-                const data = await getWarning(warnedUserOnePublicID);
-                const expected = {
-                    enabled: 0
-                };
-                assert.ok(partialDeepEquals(data, expected));
+                const data = await getWarning(publicUserID7);
+                assert.equal(data.length, 0);
                 done();
             })
             .catch(err => done(err));
@@ -166,8 +233,8 @@ describe("postWarning", () => {
 
     it("Should not be able to warn a user without reason", (done) => {
         const json = {
-            issuerUserID: warningVipOne,
-            userID: warnedUserTwoPublicID,
+            issuerUserID: vipID1,
+            userID: publicUserID8,
             enabled: true
         };
 
@@ -179,21 +246,128 @@ describe("postWarning", () => {
             .catch(err => done(err));
     });
 
-    it("Should be able to re-warn a user without reason", (done) => {
+    it("Should not be able to re-warn a user without reason", (done) => {
         const json = {
-            issuerUserID: warningVipOne,
-            userID: warnedUserOnePublicID,
+            issuerUserID: vipID1,
+            userID: publicUserID9,
             enabled: true
+        };
+
+        client.post(endpoint, json)
+            .then(res => {
+                assert.strictEqual(res.status, 400);
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it("Should be able to edit a warning if within deadline and same vip", (done) => {
+        const json = {
+            issuerUserID: vipID1,
+            userID: publicUserID10,
+            enabled: true,
+            reason: "edited reason 10",
         };
 
         client.post(endpoint, json)
             .then(async res => {
                 assert.strictEqual(res.status, 200);
-                const data = await getWarning(warnedUserOnePublicID);
+                const row = await getWarning(json.userID);
                 const expected = {
-                    enabled: 1
+                    enabled: 1,
+                    issuerUserID: publicVipID1,
+                    reason: json.reason,
                 };
-                assert.ok(partialDeepEquals(data, expected));
+                assert.equal(row.length, 1);
+                assert.ok(partialDeepEquals(row[0], expected));
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it("Should not be able to edit a warning if within deadline and different vip", (done) => {
+        const json = {
+            issuerUserID: vipID2,
+            userID: publicUserID11,
+            enabled: true,
+            reason: "edited reason 11",
+        };
+
+        client.post(endpoint, json)
+            .then(async res => {
+                assert.strictEqual(res.status, 409);
+                const row = await getWarning(json.userID);
+                const expected = {
+                    enabled: 1,
+                    issuerUserID: publicVipID1,
+                    reason: "warn reason 11",
+                };
+                assert.equal(row.length, 1);
+                assert.ok(partialDeepEquals(row[0], expected));
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it("Should be able to warn a previously warned user again (same vip)", (done) => {
+        const json = {
+            issuerUserID: vipID1,
+            userID: publicUserID12,
+            enabled: true,
+            reason: "new reason 12",
+        };
+
+        client.post(endpoint, json)
+            .then(async res => {
+                assert.strictEqual(res.status, 200);
+                const row = await getWarning(json.userID);
+                const expected = [
+                    {
+                        enabled: 0,
+                        issuerUserID: publicVipID1,
+                        reason: "warn reason 12",
+                    },
+                    {
+                        enabled: 1,
+                        issuerUserID: publicVipID1,
+                        reason: "new reason 12",
+                    }
+                ];
+                assert.equal(row.length, 2);
+                assert.ok(partialDeepEquals(row[0], expected[0]));
+                assert.ok(partialDeepEquals(row[1], expected[1]));
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it("Should be able to warn a previously warned user again (different vip)", (done) => {
+        const json = {
+            issuerUserID: vipID2,
+            userID: publicUserID13,
+            enabled: true,
+            reason: "new reason 13",
+        };
+
+        client.post(endpoint, json)
+            .then(async res => {
+                assert.strictEqual(res.status, 200);
+                const row = await getWarning(json.userID);
+                const expected = [
+                    {
+                        enabled: 0,
+                        issuerUserID: publicVipID1,
+                        reason: "warn reason 13",
+                    },
+                    {
+                        enabled: 1,
+                        issuerUserID: publicVipID2,
+                        reason: "new reason 13",
+                    }
+                ];
+                assert.equal(row.length, 2);
+                assert.ok(partialDeepEquals(row[0], expected[0]));
+                assert.ok(partialDeepEquals(row[1], expected[1]));
                 done();
             })
             .catch(err => done(err));

--- a/test/cases/postWarning.ts
+++ b/test/cases/postWarning.ts
@@ -3,74 +3,41 @@ import { db } from "../../src/databases/databases";
 import { getHash } from "../../src/utils/getHash";
 import assert from "assert";
 import { client } from "../utils/httpClient";
+import { usersForSuite } from "../utils/randomUsers";
 
 describe("postWarning", () => {
     // constants
     const endpoint = "/api/warnUser";
     const getWarning = (userID: string, type = 0) => db.prepare("all", `SELECT * FROM warnings WHERE "userID" = ? AND "type" = ? ORDER BY "issueTime" ASC`, [userID, type]);
 
-    const userID0 = "warning-0";
-    const userID1 = "warning-1";
-    const userID2 = "warning-2";
-    const userID3 = "warning-3";
-    const userID4 = "warning-4";
-    const userID5 = "warning-5";
-    const userID6 = "warning-6";
-    const userID7 = "warning-7";
-    const userID8 = "warning-8";
-    const userID9 = "warning-9";
-    const userID10 = "warning-10";
-    const userID11 = "warning-11";
-    const userID12 = "warning-12";
-    const userID13 = "warning-13";
-    const userID14 = "warning-14";
-    const publicUserID0 = getHash(userID0);
-    const publicUserID1 = getHash(userID1);
-    const publicUserID2 = getHash(userID2);
-    const publicUserID3 = getHash(userID3);
-    const publicUserID4 = getHash(userID4);
-    const publicUserID5 = getHash(userID5);
-    const publicUserID6 = getHash(userID6);
-    const publicUserID7 = getHash(userID7);
-    const publicUserID8 = getHash(userID8);
-    const publicUserID9 = getHash(userID9);
-    const publicUserID10 = getHash(userID10);
-    const publicUserID11 = getHash(userID11);
-    const publicUserID12 = getHash(userID12);
-    const publicUserID13 = getHash(userID13);
-    const publicUserID14 = getHash(userID14);
-    const vipID1 = "warning-vip-1";
-    const vipID2 = "warning-vip-2";
-    const publicVipID1 = getHash(vipID1);
-    const publicVipID2 = getHash(vipID2);
-    const nonVipUser = "warning-non-vip";
+    const users = usersForSuite("postWarning");
 
     before(async () => {
         const insertWarningQuery = 'INSERT INTO warnings ("userID", "issuerUserID", "enabled", "reason", "issueTime") VALUES(?, ?, ?, ?, ?)';
         const insertWarningQueryWithDisableTime = 'INSERT INTO warnings ("userID", "issuerUserID", "enabled", "reason", "issueTime", "disableTime") VALUES(?, ?, ?, ?, ?, ?)';
         const HOUR = 60 * 60 * 1000;
 
-        await db.prepare("run", `INSERT INTO "vipUsers" ("userID") VALUES (?)`, [publicVipID1]);
-        await db.prepare("run", `INSERT INTO "vipUsers" ("userID") VALUES (?)`, [publicVipID2]);
+        await db.prepare("run", `INSERT INTO "vipUsers" ("userID") VALUES (?)`, [users.vip1.public]);
+        await db.prepare("run", `INSERT INTO "vipUsers" ("userID") VALUES (?)`, [users.vip2.public]);
 
-        await db.prepare("run", insertWarningQuery, [publicUserID1, publicVipID1, 1, "warn reason 1", (Date.now() - 24 * HOUR)]); // 24 hours is much past the edit deadline
-        await db.prepare("run", insertWarningQuery, [publicUserID2, publicVipID1, 1, "warn reason 2", (Date.now() - 24 * HOUR)]);
-        await db.prepare("run", insertWarningQuery, [publicUserID3, publicVipID1, 1, "warn reason 3", Date.now()]);
-        await db.prepare("run", insertWarningQuery, [publicUserID4, publicVipID1, 1, "warn reason 4", Date.now()]);
-        await db.prepare("run", insertWarningQuery, [publicUserID6, publicVipID1, 1, "warn reason 6", Date.now()]);
-        await db.prepare("run", insertWarningQuery, [publicUserID9, publicVipID1, 0, "warn reason 9", Date.now()]);
-        await db.prepare("run", insertWarningQuery, [publicUserID10, publicVipID1, 1, "warn reason 10", Date.now()]);
-        await db.prepare("run", insertWarningQuery, [publicUserID11, publicVipID1, 1, "warn reason 11", Date.now()]);
-        await db.prepare("run", insertWarningQuery, [publicUserID12, publicVipID1, 0, "warn reason 12", Date.now()]);
-        await db.prepare("run", insertWarningQuery, [publicUserID13, publicVipID1, 0, "warn reason 13", Date.now()]);
-        await db.prepare("run", insertWarningQueryWithDisableTime, [publicUserID14, publicVipID1, 0, "warn reason 14", 123, 12345]);
-        await db.prepare("run", insertWarningQuery, [publicUserID14, publicVipID1, 1, "another reason 14", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [users.u1.public, users.vip1.public, 1, "warn reason 1", (Date.now() - 24 * HOUR)]); // 24 hours is much past the edit deadline
+        await db.prepare("run", insertWarningQuery, [users.u2.public, users.vip1.public, 1, "warn reason 2", (Date.now() - 24 * HOUR)]);
+        await db.prepare("run", insertWarningQuery, [users.u3.public, users.vip1.public, 1, "warn reason 3", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [users.u4.public, users.vip1.public, 1, "warn reason 4", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [users.u6.public, users.vip1.public, 1, "warn reason 6", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [users.u9.public, users.vip1.public, 0, "warn reason 9", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [users.u10.public, users.vip1.public, 1, "warn reason 10", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [users.u11.public, users.vip1.public, 1, "warn reason 11", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [users.u12.public, users.vip1.public, 0, "warn reason 12", Date.now()]);
+        await db.prepare("run", insertWarningQuery, [users.u13.public, users.vip1.public, 0, "warn reason 13", Date.now()]);
+        await db.prepare("run", insertWarningQueryWithDisableTime, [users.u14.public, users.vip1.public, 0, "warn reason 14", 123, 12345]);
+        await db.prepare("run", insertWarningQuery, [users.u14.public, users.vip1.public, 1, "another reason 14", Date.now()]);
     });
 
     it("Should be able to create warning if vip (exp 200)", (done) => {
         const json = {
-            issuerUserID: vipID1,
-            userID: publicUserID0,
+            issuerUserID: users.vip1.private,
+            userID: users.u0.public,
             reason: "warning-reason-0"
         };
         client.post(endpoint, json)
@@ -91,8 +58,8 @@ describe("postWarning", () => {
 
     it("Should be not be able to edit a warning if past deadline and same vip", (done) => {
         const json = {
-            issuerUserID: vipID1,
-            userID: publicUserID1,
+            issuerUserID: users.vip1.private,
+            userID: users.u1.public,
             reason: "edited reason 1",
         };
 
@@ -102,7 +69,7 @@ describe("postWarning", () => {
                 const row = await getWarning(json.userID);
                 const expected = {
                     enabled: 1,
-                    issuerUserID: publicVipID1,
+                    issuerUserID: users.vip1.public,
                 };
                 assert.equal(row.length, 1);
                 assert.ok(partialDeepEquals(row[0], expected));
@@ -113,8 +80,8 @@ describe("postWarning", () => {
 
     it("Should be not be able to edit a warning if past deadline and different vip", (done) => {
         const json = {
-            issuerUserID: vipID2,
-            userID: publicUserID2,
+            issuerUserID: users.vip2.private,
+            userID: users.u2.public,
             reason: "edited reason 2",
         };
 
@@ -124,7 +91,7 @@ describe("postWarning", () => {
                 const row = await getWarning(json.userID);
                 const expected = {
                     enabled: 1,
-                    issuerUserID: publicVipID1,
+                    issuerUserID: users.vip1.public,
                 };
                 assert.equal(row.length, 1);
                 assert.ok(partialDeepEquals(row[0], expected));
@@ -135,8 +102,8 @@ describe("postWarning", () => {
 
     it("Should be able to remove warning if same vip as issuer", (done) => {
         const json = {
-            issuerUserID: vipID1,
-            userID: publicUserID3,
+            issuerUserID: users.vip1.private,
+            userID: users.u3.public,
             enabled: false
         };
         const beforeTime = Date.now();
@@ -160,8 +127,8 @@ describe("postWarning", () => {
 
     it("Should be able to remove warning if not the same vip as issuer", (done) => {
         const json = {
-            issuerUserID: vipID2,
-            userID: publicUserID4,
+            issuerUserID: users.vip2.private,
+            userID: users.u4.public,
             enabled: false
         };
         const beforeTime = Date.now();
@@ -185,8 +152,8 @@ describe("postWarning", () => {
 
     it("Should not be able to create warning if not vip (exp 403)", (done) => {
         const json = {
-            issuerUserID: nonVipUser,
-            userID: publicUserID5,
+            issuerUserID: users.nonvip.private,
+            userID: users.u5.public,
             reason: "warn reason 5",
         };
 
@@ -209,7 +176,7 @@ describe("postWarning", () => {
 
     it("Should be able to remove your own warning", (done) => {
         const json = {
-            userID: userID6,
+            userID: users.u6.private,
             enabled: false
         };
         const beforeTime = Date.now();
@@ -218,7 +185,7 @@ describe("postWarning", () => {
             .then(async res => {
                 const afterTime = Date.now();
                 assert.strictEqual(res.status, 200);
-                const row = await getWarning(publicUserID6);
+                const row = await getWarning(users.u6.public);
                 const expected = {
                     enabled: 0
                 };
@@ -233,7 +200,7 @@ describe("postWarning", () => {
 
     it("Should not be able to add your own warning", (done) => {
         const json = {
-            userID: userID7,
+            userID: users.u7.private,
             enabled: true,
             reason: "warn reason 7",
         };
@@ -241,7 +208,7 @@ describe("postWarning", () => {
         client.post(endpoint, json)
             .then(async res => {
                 assert.strictEqual(res.status, 403);
-                const data = await getWarning(publicUserID7);
+                const data = await getWarning(users.u7.public);
                 assert.equal(data.length, 0);
                 done();
             })
@@ -250,8 +217,8 @@ describe("postWarning", () => {
 
     it("Should not be able to warn a user without reason", (done) => {
         const json = {
-            issuerUserID: vipID1,
-            userID: publicUserID8,
+            issuerUserID: users.vip1.private,
+            userID: users.u8.public,
             enabled: true
         };
 
@@ -265,8 +232,8 @@ describe("postWarning", () => {
 
     it("Should not be able to re-warn a user without reason", (done) => {
         const json = {
-            issuerUserID: vipID1,
-            userID: publicUserID9,
+            issuerUserID: users.vip1.private,
+            userID: users.u9.public,
             enabled: true
         };
 
@@ -280,8 +247,8 @@ describe("postWarning", () => {
 
     it("Should be able to edit a warning if within deadline and same vip", (done) => {
         const json = {
-            issuerUserID: vipID1,
-            userID: publicUserID10,
+            issuerUserID: users.vip1.private,
+            userID: users.u10.public,
             enabled: true,
             reason: "edited reason 10",
         };
@@ -292,7 +259,7 @@ describe("postWarning", () => {
                 const row = await getWarning(json.userID);
                 const expected = {
                     enabled: 1,
-                    issuerUserID: publicVipID1,
+                    issuerUserID: users.vip1.public,
                     reason: json.reason,
                 };
                 assert.equal(row.length, 1);
@@ -304,8 +271,8 @@ describe("postWarning", () => {
 
     it("Should not be able to edit a warning if within deadline and different vip", (done) => {
         const json = {
-            issuerUserID: vipID2,
-            userID: publicUserID11,
+            issuerUserID: users.vip2.private,
+            userID: users.u11.public,
             enabled: true,
             reason: "edited reason 11",
         };
@@ -316,7 +283,7 @@ describe("postWarning", () => {
                 const row = await getWarning(json.userID);
                 const expected = {
                     enabled: 1,
-                    issuerUserID: publicVipID1,
+                    issuerUserID: users.vip1.public,
                     reason: "warn reason 11",
                 };
                 assert.equal(row.length, 1);
@@ -328,8 +295,8 @@ describe("postWarning", () => {
 
     it("Should be able to warn a previously warned user again (same vip)", (done) => {
         const json = {
-            issuerUserID: vipID1,
-            userID: publicUserID12,
+            issuerUserID: users.vip1.private,
+            userID: users.u12.public,
             enabled: true,
             reason: "new reason 12",
         };
@@ -341,12 +308,12 @@ describe("postWarning", () => {
                 const expected = [
                     {
                         enabled: 0,
-                        issuerUserID: publicVipID1,
+                        issuerUserID: users.vip1.public,
                         reason: "warn reason 12",
                     },
                     {
                         enabled: 1,
-                        issuerUserID: publicVipID1,
+                        issuerUserID: users.vip1.public,
                         reason: "new reason 12",
                     }
                 ];
@@ -360,8 +327,8 @@ describe("postWarning", () => {
 
     it("Should be able to warn a previously warned user again (different vip)", (done) => {
         const json = {
-            issuerUserID: vipID2,
-            userID: publicUserID13,
+            issuerUserID: users.vip2.private,
+            userID: users.u13.public,
             enabled: true,
             reason: "new reason 13",
         };
@@ -373,12 +340,12 @@ describe("postWarning", () => {
                 const expected = [
                     {
                         enabled: 0,
-                        issuerUserID: publicVipID1,
+                        issuerUserID: users.vip1.public,
                         reason: "warn reason 13",
                     },
                     {
                         enabled: 1,
-                        issuerUserID: publicVipID2,
+                        issuerUserID: users.vip2.public,
                         reason: "new reason 13",
                     }
                 ];
@@ -392,8 +359,8 @@ describe("postWarning", () => {
 
     it("Disabling a warning should only set disableTime for the active warning", (done) => {
         const json = {
-            issuerUserID: vipID2,
-            userID: publicUserID14,
+            issuerUserID: users.vip2.private,
+            userID: users.u14.public,
             enabled: false,
         };
         const beforeTime = Date.now();
@@ -406,13 +373,13 @@ describe("postWarning", () => {
                 const expected = [
                     {
                         enabled: 0,
-                        issuerUserID: publicVipID1,
+                        issuerUserID: users.vip1.public,
                         reason: "warn reason 14",
                         disableTime: 12345,
                     },
                     {
                         enabled: 0,
-                        issuerUserID: publicVipID1,
+                        issuerUserID: users.vip1.public,
                         reason: "another reason 14",
                     }
                 ];

--- a/test/cases/postWarning.ts
+++ b/test/cases/postWarning.ts
@@ -34,73 +34,61 @@ describe("postWarning", () => {
         await db.prepare("run", insertWarningQuery, [users.u14.public, users.vip1.public, 1, "another reason 14", Date.now()]);
     });
 
-    it("Should be able to create warning if vip (exp 200)", (done) => {
+    it("Should be able to create warning if vip (exp 200)", async () => {
         const json = {
             issuerUserID: users.vip1.private,
             userID: users.u0.public,
             reason: "warning-reason-0"
         };
-        client.post(endpoint, json)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getWarning(json.userID);
-                const expected = {
-                    enabled: 1,
-                    issuerUserID: getHash(json.issuerUserID),
-                    reason: json.reason,
-                };
-                assert.equal(row.length, 1);
-                assert.ok(partialDeepEquals(row[0], expected));
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        assert.strictEqual(res.status, 200);
+        const row = await getWarning(json.userID);
+        const expected = {
+            enabled: 1,
+            issuerUserID: getHash(json.issuerUserID),
+            reason: json.reason,
+        };
+        assert.equal(row.length, 1);
+        assert.ok(partialDeepEquals(row[0], expected));
     });
 
-    it("Should be not be able to edit a warning if past deadline and same vip", (done) => {
+    it("Should be not be able to edit a warning if past deadline and same vip", async () => {
         const json = {
             issuerUserID: users.vip1.private,
             userID: users.u1.public,
             reason: "edited reason 1",
         };
 
-        client.post(endpoint, json)
-            .then(async res => {
-                assert.strictEqual(res.status, 409);
-                const row = await getWarning(json.userID);
-                const expected = {
-                    enabled: 1,
-                    issuerUserID: users.vip1.public,
-                };
-                assert.equal(row.length, 1);
-                assert.ok(partialDeepEquals(row[0], expected));
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        assert.strictEqual(res.status, 409);
+        const row = await getWarning(json.userID);
+        const expected = {
+            enabled: 1,
+            issuerUserID: users.vip1.public,
+        };
+        assert.equal(row.length, 1);
+        assert.ok(partialDeepEquals(row[0], expected));
     });
 
-    it("Should be not be able to edit a warning if past deadline and different vip", (done) => {
+    it("Should be not be able to edit a warning if past deadline and different vip", async () => {
         const json = {
             issuerUserID: users.vip2.private,
             userID: users.u2.public,
             reason: "edited reason 2",
         };
 
-        client.post(endpoint, json)
-            .then(async res => {
-                assert.strictEqual(res.status, 409);
-                const row = await getWarning(json.userID);
-                const expected = {
-                    enabled: 1,
-                    issuerUserID: users.vip1.public,
-                };
-                assert.equal(row.length, 1);
-                assert.ok(partialDeepEquals(row[0], expected));
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        assert.strictEqual(res.status, 409);
+        const row = await getWarning(json.userID);
+        const expected = {
+            enabled: 1,
+            issuerUserID: users.vip1.public,
+        };
+        assert.equal(row.length, 1);
+        assert.ok(partialDeepEquals(row[0], expected));
     });
 
-    it("Should be able to remove warning if same vip as issuer", (done) => {
+    it("Should be able to remove warning if same vip as issuer", async () => {
         const json = {
             issuerUserID: users.vip1.private,
             userID: users.u3.public,
@@ -108,24 +96,20 @@ describe("postWarning", () => {
         };
         const beforeTime = Date.now();
 
-        client.post(endpoint, json)
-            .then(async res => {
-                const afterTime = Date.now();
-                assert.strictEqual(res.status, 200);
-                const row = await getWarning(json.userID);
-                const expected = {
-                    enabled: 0
-                };
-                assert.equal(row.length, 1);
-                assert.ok(partialDeepEquals(row[0], expected));
-                // check disableTime
-                assert.ok(row[0].disableTime >= beforeTime && row[0].disableTime <= afterTime, "expected disableTime to be somewhere between execution start and end");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        const afterTime = Date.now();
+        assert.strictEqual(res.status, 200);
+        const row = await getWarning(json.userID);
+        const expected = {
+            enabled: 0
+        };
+        assert.equal(row.length, 1);
+        assert.ok(partialDeepEquals(row[0], expected));
+        // check disableTime
+        assert.ok(row[0].disableTime >= beforeTime && row[0].disableTime <= afterTime, "expected disableTime to be somewhere between execution start and end");
     });
 
-    it("Should be able to remove warning if not the same vip as issuer", (done) => {
+    it("Should be able to remove warning if not the same vip as issuer", async () => {
         const json = {
             issuerUserID: users.vip2.private,
             userID: users.u4.public,
@@ -133,119 +117,91 @@ describe("postWarning", () => {
         };
         const beforeTime = Date.now();
 
-        client.post(endpoint, json)
-            .then(async res => {
-                const afterTime = Date.now();
-                assert.strictEqual(res.status, 200);
-                const row = await getWarning(json.userID);
-                const expected = {
-                    enabled: 0
-                };
-                assert.equal(row.length, 1);
-                assert.ok(partialDeepEquals(row[0], expected));
-                // check disableTime
-                assert.ok(row[0].disableTime >= beforeTime && row[0].disableTime <= afterTime, "expected disableTime to be somewhere between execution start and end");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        const afterTime = Date.now();
+        assert.strictEqual(res.status, 200);
+        const row = await getWarning(json.userID);
+        const expected = {
+            enabled: 0
+        };
+        assert.equal(row.length, 1);
+        assert.ok(partialDeepEquals(row[0], expected));
+        // check disableTime
+        assert.ok(row[0].disableTime >= beforeTime && row[0].disableTime <= afterTime, "expected disableTime to be somewhere between execution start and end");
     });
 
-    it("Should not be able to create warning if not vip (exp 403)", (done) => {
+    it("Should not be able to create warning if not vip (exp 403)", async () => {
         const json = {
             issuerUserID: users.nonvip.private,
             userID: users.u5.public,
             reason: "warn reason 5",
         };
 
-        client.post(endpoint, json)
-            .then(res => {
-                assert.strictEqual(res.status, 403);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        assert.strictEqual(res.status, 403);
     });
 
-    it("Should return 400 if missing body", (done) => {
-        client.post(endpoint, {})
-            .then(res => {
-                assert.strictEqual(res.status, 400);
-                done();
-            })
-            .catch(err => done(err));
+    it("Should return 400 if missing body", async () => {
+        const res = await client.post(endpoint, {});
+        assert.strictEqual(res.status, 400);
     });
 
-    it("Should be able to remove your own warning", (done) => {
+    it("Should be able to remove your own warning", async () => {
         const json = {
             userID: users.u6.private,
             enabled: false
         };
         const beforeTime = Date.now();
 
-        client.post(endpoint, json)
-            .then(async res => {
-                const afterTime = Date.now();
-                assert.strictEqual(res.status, 200);
-                const row = await getWarning(users.u6.public);
-                const expected = {
-                    enabled: 0
-                };
-                assert.equal(row.length, 1);
-                assert.ok(partialDeepEquals(row[0], expected));
-                // check disableTime
-                assert.ok(row[0].disableTime >= beforeTime && row[0].disableTime <= afterTime, "expected disableTime to be somewhere between execution start and end");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        const afterTime = Date.now();
+        assert.strictEqual(res.status, 200);
+        const row = await getWarning(users.u6.public);
+        const expected = {
+            enabled: 0
+        };
+        assert.equal(row.length, 1);
+        assert.ok(partialDeepEquals(row[0], expected));
+        // check disableTime
+        assert.ok(row[0].disableTime >= beforeTime && row[0].disableTime <= afterTime, "expected disableTime to be somewhere between execution start and end");
     });
 
-    it("Should not be able to add your own warning", (done) => {
+    it("Should not be able to add your own warning", async () => {
         const json = {
             userID: users.u7.private,
             enabled: true,
             reason: "warn reason 7",
         };
 
-        client.post(endpoint, json)
-            .then(async res => {
-                assert.strictEqual(res.status, 403);
-                const data = await getWarning(users.u7.public);
-                assert.equal(data.length, 0);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        assert.strictEqual(res.status, 403);
+        const data = await getWarning(users.u7.public);
+        assert.equal(data.length, 0);
     });
 
-    it("Should not be able to warn a user without reason", (done) => {
+    it("Should not be able to warn a user without reason", async () => {
         const json = {
             issuerUserID: users.vip1.private,
             userID: users.u8.public,
             enabled: true
         };
 
-        client.post(endpoint, json)
-            .then(res => {
-                assert.strictEqual(res.status, 400);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        assert.strictEqual(res.status, 400);
     });
 
-    it("Should not be able to re-warn a user without reason", (done) => {
+    it("Should not be able to re-warn a user without reason", async () => {
         const json = {
             issuerUserID: users.vip1.private,
             userID: users.u9.public,
             enabled: true
         };
 
-        client.post(endpoint, json)
-            .then(res => {
-                assert.strictEqual(res.status, 400);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        assert.strictEqual(res.status, 400);
     });
 
-    it("Should be able to edit a warning if within deadline and same vip", (done) => {
+    it("Should be able to edit a warning if within deadline and same vip", async () => {
         const json = {
             issuerUserID: users.vip1.private,
             userID: users.u10.public,
@@ -253,23 +209,19 @@ describe("postWarning", () => {
             reason: "edited reason 10",
         };
 
-        client.post(endpoint, json)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getWarning(json.userID);
-                const expected = {
-                    enabled: 1,
-                    issuerUserID: users.vip1.public,
-                    reason: json.reason,
-                };
-                assert.equal(row.length, 1);
-                assert.ok(partialDeepEquals(row[0], expected));
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        assert.strictEqual(res.status, 200);
+        const row = await getWarning(json.userID);
+        const expected = {
+            enabled: 1,
+            issuerUserID: users.vip1.public,
+            reason: json.reason,
+        };
+        assert.equal(row.length, 1);
+        assert.ok(partialDeepEquals(row[0], expected));
     });
 
-    it("Should not be able to edit a warning if within deadline and different vip", (done) => {
+    it("Should not be able to edit a warning if within deadline and different vip", async () => {
         const json = {
             issuerUserID: users.vip2.private,
             userID: users.u11.public,
@@ -277,23 +229,19 @@ describe("postWarning", () => {
             reason: "edited reason 11",
         };
 
-        client.post(endpoint, json)
-            .then(async res => {
-                assert.strictEqual(res.status, 409);
-                const row = await getWarning(json.userID);
-                const expected = {
-                    enabled: 1,
-                    issuerUserID: users.vip1.public,
-                    reason: "warn reason 11",
-                };
-                assert.equal(row.length, 1);
-                assert.ok(partialDeepEquals(row[0], expected));
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        assert.strictEqual(res.status, 409);
+        const row = await getWarning(json.userID);
+        const expected = {
+            enabled: 1,
+            issuerUserID: users.vip1.public,
+            reason: "warn reason 11",
+        };
+        assert.equal(row.length, 1);
+        assert.ok(partialDeepEquals(row[0], expected));
     });
 
-    it("Should be able to warn a previously warned user again (same vip)", (done) => {
+    it("Should be able to warn a previously warned user again (same vip)", async () => {
         const json = {
             issuerUserID: users.vip1.private,
             userID: users.u12.public,
@@ -301,31 +249,27 @@ describe("postWarning", () => {
             reason: "new reason 12",
         };
 
-        client.post(endpoint, json)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getWarning(json.userID);
-                const expected = [
-                    {
-                        enabled: 0,
-                        issuerUserID: users.vip1.public,
-                        reason: "warn reason 12",
-                    },
-                    {
-                        enabled: 1,
-                        issuerUserID: users.vip1.public,
-                        reason: "new reason 12",
-                    }
-                ];
-                assert.equal(row.length, 2);
-                assert.ok(partialDeepEquals(row[0], expected[0]), "warning 1");
-                assert.ok(partialDeepEquals(row[1], expected[1]), "warning 2");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        assert.strictEqual(res.status, 200);
+        const row = await getWarning(json.userID);
+        const expected = [
+            {
+                enabled: 0,
+                issuerUserID: users.vip1.public,
+                reason: "warn reason 12",
+            },
+            {
+                enabled: 1,
+                issuerUserID: users.vip1.public,
+                reason: "new reason 12",
+            }
+        ];
+        assert.equal(row.length, 2);
+        assert.ok(partialDeepEquals(row[0], expected[0]), "warning 1");
+        assert.ok(partialDeepEquals(row[1], expected[1]), "warning 2");
     });
 
-    it("Should be able to warn a previously warned user again (different vip)", (done) => {
+    it("Should be able to warn a previously warned user again (different vip)", async () => {
         const json = {
             issuerUserID: users.vip2.private,
             userID: users.u13.public,
@@ -333,31 +277,27 @@ describe("postWarning", () => {
             reason: "new reason 13",
         };
 
-        client.post(endpoint, json)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getWarning(json.userID);
-                const expected = [
-                    {
-                        enabled: 0,
-                        issuerUserID: users.vip1.public,
-                        reason: "warn reason 13",
-                    },
-                    {
-                        enabled: 1,
-                        issuerUserID: users.vip2.public,
-                        reason: "new reason 13",
-                    }
-                ];
-                assert.equal(row.length, 2);
-                assert.ok(partialDeepEquals(row[0], expected[0]), "warning 1");
-                assert.ok(partialDeepEquals(row[1], expected[1]), "warning 2");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        assert.strictEqual(res.status, 200);
+        const row = await getWarning(json.userID);
+        const expected = [
+            {
+                enabled: 0,
+                issuerUserID: users.vip1.public,
+                reason: "warn reason 13",
+            },
+            {
+                enabled: 1,
+                issuerUserID: users.vip2.public,
+                reason: "new reason 13",
+            }
+        ];
+        assert.equal(row.length, 2);
+        assert.ok(partialDeepEquals(row[0], expected[0]), "warning 1");
+        assert.ok(partialDeepEquals(row[1], expected[1]), "warning 2");
     });
 
-    it("Disabling a warning should only set disableTime for the active warning", (done) => {
+    it("Disabling a warning should only set disableTime for the active warning", async () => {
         const json = {
             issuerUserID: users.vip2.private,
             userID: users.u14.public,
@@ -365,31 +305,27 @@ describe("postWarning", () => {
         };
         const beforeTime = Date.now();
 
-        client.post(endpoint, json)
-            .then(async res => {
-                const afterTime = Date.now();
-                assert.strictEqual(res.status, 200);
-                const row = await getWarning(json.userID);
-                const expected = [
-                    {
-                        enabled: 0,
-                        issuerUserID: users.vip1.public,
-                        reason: "warn reason 14",
-                        disableTime: 12345,
-                    },
-                    {
-                        enabled: 0,
-                        issuerUserID: users.vip1.public,
-                        reason: "another reason 14",
-                    }
-                ];
-                assert.equal(row.length, 2);
-                assert.ok(partialDeepEquals(row[0], expected[0]), "warning 1");
-                assert.ok(partialDeepEquals(row[1], expected[1]), "warning 2");
-                // check disableTime
-                assert.ok(row[1].disableTime >= beforeTime && row[1].disableTime <= afterTime, "expected disableTime to be somewhere between execution start and end");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await client.post(endpoint, json);
+        const afterTime = Date.now();
+        assert.strictEqual(res.status, 200);
+        const row = await getWarning(json.userID);
+        const expected = [
+            {
+                enabled: 0,
+                issuerUserID: users.vip1.public,
+                reason: "warn reason 14",
+                disableTime: 12345,
+            },
+            {
+                enabled: 0,
+                issuerUserID: users.vip1.public,
+                reason: "another reason 14",
+            }
+        ];
+        assert.equal(row.length, 2);
+        assert.ok(partialDeepEquals(row[0], expected[0]), "warning 1");
+        assert.ok(partialDeepEquals(row[1], expected[1]), "warning 2");
+        // check disableTime
+        assert.ok(row[1].disableTime >= beforeTime && row[1].disableTime <= afterTime, "expected disableTime to be somewhere between execution start and end");
     });
 });

--- a/test/cases/redisTest.ts
+++ b/test/cases/redisTest.ts
@@ -9,44 +9,32 @@ const randKey2 = genRandom(16);
 const randKey3 = genRandom();
 const randValue3 = genRandom();
 
-const redisGetCheck = (key: string, expected: string | null, done: Mocha.Done): Promise<void> =>
-    redis.get(key)
-        .then(res => {
-            assert.strictEqual(res, expected);
-            done();
-        }).catch(err => done(err));
-
 describe("redis test", function() {
     before(async function() {
         if (!config.redis?.enabled) this.skip();
         await redis.set(randKey1, randValue1);
     });
-    it("Should get stored value", (done) => {
-        redisGetCheck(randKey1, randValue1, done);
+    it("Should get stored value", async () => {
+        const res = await redis.get(randKey1);
+        assert.strictEqual(res, randValue1);
     });
-    it("Should not be able to get not stored value", (done) => {
-        redis.get(randKey2)
-            .then(res => {
-                if (res) done("Value should not be found");
-                done();
-            }).catch(err => done(err));
+    it("Should not be able to get not stored value", async () => {
+        const res = await redis.get(randKey2);
+        assert.strictEqual(res, null, "Value should not be found");
     });
-    it("Should be able to delete stored value", (done) => {
-        redis.del(randKey1)
-            .catch(err => done(err))
-            .then(() => redisGetCheck(randKey1, null, done));
+    it("Should be able to delete stored value", async () => {
+        await redis.del(randKey1);
+        const res = await redis.get(randKey1);
+        assert.strictEqual(res, null, "Deleted key should not be found");
     });
-    it("Should be able to set expiring value", (done) => {
-        redis.setEx(randKey3, 8400, randValue3)
-            .catch(err => done(err))
-            .then(() => redisGetCheck(randKey3, randValue3, done));
+    it("Should be able to set expiring value", async () => {
+        await redis.setEx(randKey3, 8400, randValue3);
+        const res = await redis.get(randKey3);
+        assert.strictEqual(res, randValue3);
     });
-    it("Should continue when undefined value is fetched", (done) => {
+    it("Should continue when undefined value is fetched", async () => {
         const undefkey = `undefined.${genRandom()}`;
-        redis.get(undefkey)
-            .then(result => {
-                assert.ok(!result); // result should be falsy
-                done();
-            });
+        const res = await redis.get(undefkey);
+        assert.strictEqual(res, null);
     });
 });

--- a/test/cases/setUsernamePrivate.ts
+++ b/test/cases/setUsernamePrivate.ts
@@ -59,71 +59,47 @@ describe("setUsernamePrivate tests", () => {
     before(() => sinon.stub(config, "minUserIDLength").value(USERID_LIMIT));
     after(() => sinon.restore());
 
-    it("Existing privateID = username under Limit should retreive successfully", (done) => {
+    it("Existing privateID = username under Limit should retreive successfully", async () => {
         const privateID = preExisting_underLimit;
-        hasSetUsername(getHash(privateID))
-            .then((usernameInfo) => {
-                assert.ok(usernameInfo);
-                done();
-            });
+        assert.ok(await hasSetUsername(getHash(privateID)));
     });
 
-    it("Existing privateID = username over Limit should retreive successfully", (done) => {
+    it("Existing privateID = username over Limit should retreive successfully", async () => {
         const privateID = preExisting_overLimit;
-        hasSetUsername(getHash(privateID))
-            .then((usernameInfo) => {
-                assert.ok(usernameInfo);
-                done();
-            });
+        assert.ok(await hasSetUsername(getHash(privateID)));
     });
 
-    it("Should return error if trying to set userID = username under limit", (done) => {
+    it("Should return error if trying to set userID = username under limit", async () => {
         const privateID = newUser_underLimit;
-        postSetUserName(privateID, privateID)
-            .then(async (res) => {
-                assert.strictEqual(res.status, 400);
-                const usernameInfo = await hasSetUsername(getHash(privateID));
-                assert.ok(!usernameInfo);
-                done();
-            })
-            .catch((err) => done(err));
+        const res = await postSetUserName(privateID, privateID);
+        assert.strictEqual(res.status, 400);
+        const usernameInfo = await hasSetUsername(getHash(privateID));
+        assert.ok(!usernameInfo);
     });
 
-    it("Should return error if trying to set username = other privateID over limit", (done) => {
+    it("Should return error if trying to set username = other privateID over limit", async () => {
         const privateID = newUser_overLimit;
-        postSetUserName(privateID, privateID)
-            .then(async (res) => {
-                assert.strictEqual(res.status, 400);
-                const usernameInfo = await hasSetUsername(getHash(privateID));
-                assert.ok(!usernameInfo);
-                done();
-            })
-            .catch((err) => done(err));
+        const res = await postSetUserName(privateID, privateID);
+        assert.strictEqual(res.status, 400);
+        const usernameInfo = await hasSetUsername(getHash(privateID));
+        assert.ok(!usernameInfo);
     });
 
-    it("Should return error if trying to set username = other privateID over limit", (done) => {
+    it("Should return error if trying to set username = other privateID over limit", async () => {
         const privateID = otherUser;
         const otherUserPrivate = preExisting_overLimit;
-        postSetUserName(privateID, otherUserPrivate)
-            .then(async (res) => {
-                assert.strictEqual(res.status, 400);
-                const usernameInfo = await hasSetUsername(getHash(privateID));
-                assert.ok(!usernameInfo);
-                done();
-            })
-            .catch((err) => done(err));
+        const res = await postSetUserName(privateID, otherUserPrivate);
+        assert.strictEqual(res.status, 400);
+        const usernameInfo = await hasSetUsername(getHash(privateID));
+        assert.ok(!usernameInfo);
     });
 
-    it("Should not return error if trying to set username = other privateID under limit", (done) => {
+    it("Should not return error if trying to set username = other privateID under limit", async () => {
         const privateID = otherUser;
         const otherUserPrivate = preExisting_underLimit;
-        postSetUserName(privateID, otherUserPrivate)
-            .then(async (res) => {
-                assert.strictEqual(res.status, 200);
-                const usernameInfo = await hasSetUsername(getHash(privateID));
-                assert.ok(usernameInfo);
-                done();
-            })
-            .catch((err) => done(err));
+        const res = await postSetUserName(privateID, otherUserPrivate);
+        assert.strictEqual(res.status, 200);
+        const usernameInfo = await hasSetUsername(getHash(privateID));
+        assert.ok(usernameInfo);
     });
 });

--- a/test/cases/shadowBanUser.ts
+++ b/test/cases/shadowBanUser.ts
@@ -1,4 +1,4 @@
-import { db, privateDB } from "../../src/databases/databases";
+import { db } from "../../src/databases/databases";
 import { getHash } from "../../src/utils/getHash";
 import assert from "assert";
 import { Category, Service } from "../../src/types/segments.model";

--- a/test/cases/tokenUtils.ts
+++ b/test/cases/tokenUtils.ts
@@ -16,32 +16,24 @@ describe("tokenUtils test", function() {
         mock.onGet(/identity/).reply(200, patreon.activeIdentity);
     });
 
-    it("Should be able to create patreon token", function (done) {
-        if (!config?.patreon) this.skip();
-        tokenUtils.createAndSaveToken(tokenUtils.TokenType.patreon, "test_code").then((licenseKey) => {
-            assert.ok(validateToken(licenseKey[0]));
-            done();
-        });
+    it("Should be able to create patreon token", async function () {
+        if (!config?.patreon) return this.skip();
+        const licenseKey = await tokenUtils.createAndSaveToken(tokenUtils.TokenType.patreon, "test_code");
+        assert.ok(validateToken(licenseKey[0]));
     });
-    it("Should be able to create local token", (done) => {
-        tokenUtils.createAndSaveToken(tokenUtils.TokenType.local).then((licenseKey) => {
-            assert.ok(validateToken(licenseKey[0]));
-            done();
-        });
+    it("Should be able to create local token", async () => {
+        const licenseKey = await tokenUtils.createAndSaveToken(tokenUtils.TokenType.local);
+        assert.ok(validateToken(licenseKey[0]));
     });
-    it("Should be able to get patreon identity", function (done) {
-        if (!config?.patreon) this.skip();
-        tokenUtils.getPatreonIdentity("fake_access_token").then((result) => {
-            assert.deepEqual(result, patreon.activeIdentity);
-            done();
-        });
+    it("Should be able to get patreon identity", async function () {
+        if (!config?.patreon) return this.skip();
+        const result = await tokenUtils.getPatreonIdentity("fake_access_token");
+        assert.deepEqual(result, patreon.activeIdentity);
     });
-    it("Should be able to refresh token", function (done) {
-        if (!config?.patreon) this.skip();
-        tokenUtils.refreshToken(tokenUtils.TokenType.patreon, "fake-licence-Key", "fake_refresh_token").then((result) => {
-            assert.strictEqual(result, true);
-            done();
-        });
+    it("Should be able to refresh token", async function () {
+        if (!config?.patreon) return this.skip();
+        const result = await tokenUtils.refreshToken(tokenUtils.TokenType.patreon, "fake-licence-Key", "fake_refresh_token");
+        assert.strictEqual(result, true);
     });
 
     after(function () {
@@ -56,17 +48,13 @@ describe("tokenUtils failing tests", function() {
         mock.onGet(/identity/).reply(204, patreon.activeIdentity);
     });
 
-    it("Should fail if patreon is not correctly stubbed", function (done) {
-        tokenUtils.createAndSaveToken(tokenUtils.TokenType.patreon, "test_code").then((licenseKey) => {
-            assert.strictEqual(licenseKey, null);
-            done();
-        });
+    it("Should fail if patreon is not correctly stubbed", async () => {
+        const licenseKey = await tokenUtils.createAndSaveToken(tokenUtils.TokenType.patreon, "test_code");
+        assert.strictEqual(licenseKey, null);
     });
-    it("Should fail if token type is invalid", (done) => {
-        tokenUtils.createAndSaveToken("invalidTokenType" as tokenUtils.TokenType).then((licenseKey) => {
-            assert.strictEqual(licenseKey, null);
-            done();
-        });
+    it("Should fail if token type is invalid", async () => {
+        const licenseKey = await tokenUtils.createAndSaveToken("invalidTokenType" as tokenUtils.TokenType);
+        assert.strictEqual(licenseKey, null);
     });
 
     after(function () {

--- a/test/cases/voteOnSponsorTime.ts
+++ b/test/cases/voteOnSponsorTime.ts
@@ -1,4 +1,3 @@
-import { config } from "../../src/config";
 import { db, privateDB } from "../../src/databases/databases";
 import { getHash } from "../../src/utils/getHash";
 import { ImportMock } from "ts-mock-imports";
@@ -26,8 +25,6 @@ describe("voteOnSponsorTime", () => {
         const warnUser01Hash = getHash("warn-voteuser01");
         const warnUser02Hash = getHash("warn-voteuser02");
         const categoryChangeUserHash = getHash(categoryChangeUser);
-        const MILLISECONDS_IN_HOUR = 3600000;
-        const warningExpireTime = MILLISECONDS_IN_HOUR * config.hoursAfterWarningExpires;
 
         const insertSponsorTimeQuery = 'INSERT INTO "sponsorTimes" ("videoID", "startTime", "endTime", "votes", "locked", "UUID", "userID", "timeSubmitted", "views", "category", "actionType", "shadowHidden", "hidden") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
         await db.prepare("run", insertSponsorTimeQuery, ["vote-testtesttest", 1, 11, 2, 0, "vote-uuid-0", "testman", 0, 50, "sponsor", "skip", 0, 0]);
@@ -96,8 +93,6 @@ describe("voteOnSponsorTime", () => {
         await db.prepare("run", insertWarningQuery, [warnUser01Hash, (now - 2000), warnVip01Hash,  1]);
         await db.prepare("run", insertWarningQuery, [warnUser01Hash, (now - 3601000), warnVip01Hash,  1]);
         await db.prepare("run", insertWarningQuery, [warnUser02Hash, now, warnVip01Hash,  1]);
-        await db.prepare("run", insertWarningQuery, [warnUser02Hash, (now - (warningExpireTime + 1000)), warnVip01Hash,  1]);
-        await db.prepare("run", insertWarningQuery, [warnUser02Hash, (now - (warningExpireTime + 2000)), warnVip01Hash,  1]);
 
 
         await db.prepare("run", 'INSERT INTO "vipUsers" ("userID") VALUES (?)', [getHash(vipUser)]);

--- a/test/cases/voteOnSponsorTime.ts
+++ b/test/cases/voteOnSponsorTime.ts
@@ -128,705 +128,486 @@ describe("voteOnSponsorTime", () => {
     const getSegmentCategory = (UUID: string) => db.prepare("get", `SELECT "category" FROM "sponsorTimes" WHERE "UUID" = ?`, [UUID]);
     const getPrivateVoteInfo = (UUID: string) => privateDB.prepare("all", `SELECT * FROM "votes" WHERE "UUID" = ?`, [UUID]);
 
-    it("Should be able to upvote a segment", (done) => {
+    it("Should be able to upvote a segment", async () => {
         const UUID = "vote-uuid-0";
-        postVote("randomID", UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 3);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote("randomID", UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 3);
     });
 
-    it("Should be able to upvote a segment with a partial ID", (done) => {
+    it("Should be able to upvote a segment with a partial ID", async () => {
         const UUID = "vote-u34113123";
-        postVote("randomIDpartial", UUID.substring(0, 9), 1, "vote-testtesttest---sdaas")
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 3);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote("randomIDpartial", UUID.substring(0, 9), 1, "vote-testtesttest---sdaas");
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 3);
     });
 
-    it("Should be able to downvote a segment", (done) => {
+    it("Should be able to downvote a segment", async () => {
         const UUID = "vote-uuid-2";
-        postVote(randomID2, UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.ok(row.votes < 10);
-                const voteInfo = await getPrivateVoteInfo(UUID);
-                assert.strictEqual(voteInfo.length, 1);
-                assert.strictEqual(voteInfo[0].normalUserID, randomID2Hashed);
-                assert.strictEqual(voteInfo[0].type, 0);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(randomID2, UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.ok(row.votes < 10);
+        const voteInfo = await getPrivateVoteInfo(UUID);
+        assert.strictEqual(voteInfo.length, 1);
+        assert.strictEqual(voteInfo[0].normalUserID, randomID2Hashed);
+        assert.strictEqual(voteInfo[0].type, 0);
     });
 
-    it("Should not be able to downvote the same segment when voting from a different user on the same IP", (done) => {
+    it("Should not be able to downvote the same segment when voting from a different user on the same IP", async () => {
         const UUID = "vote-uuid-2";
-        postVote("randomID3", UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 9);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote("randomID3", UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 9);
     });
 
-    it("Should not be able to downvote a segment if the user is shadow banned", (done) => {
+    it("Should not be able to downvote a segment if the user is shadow banned", async () => {
         const UUID = "vote-uuid-1.6";
-        postVote("randomID4", UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 10);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote("randomID4", UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 10);
     });
 
-    it("Should not be able to upvote a segment if the user hasn't submitted yet", (done) => {
+    it("Should not be able to upvote a segment if the user hasn't submitted yet", async () => {
         const UUID = "vote-uuid-1";
-        postVote("hasNotSubmittedID", UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 2);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote("hasNotSubmittedID", UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 2);
     });
 
-    it("Should not be able to downvote a segment if the user hasn't submitted yet", (done) => {
+    it("Should not be able to downvote a segment if the user hasn't submitted yet", async () => {
         const UUID = "vote-uuid-1.5";
-        postVote("hasNotSubmittedID", UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 10);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote("hasNotSubmittedID", UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 10);
     });
 
-    it("VIP should be able to completely downvote a segment", (done) => {
+    it("VIP should be able to completely downvote a segment", async () => {
         const UUID = "vote-uuid-3";
-        postVote(vipUser, UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.ok(row.votes <= -2);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(vipUser, UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.ok(row.votes <= -2);
     });
 
-    it("should be able to completely downvote your own segment (segment unlocked)", (done) => {
+    it("should be able to completely downvote your own segment (segment unlocked)", async () => {
         const UUID = "own-submission-uuid";
-        postVote("own-submission-id", UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.ok(row.votes <= -2);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote("own-submission-id", UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.ok(row.votes <= -2);
     });
 
-    it("should not be able to completely downvote somebody elses segment", (done) => {
+    it("should not be able to completely downvote somebody elses segment", async () => {
         const UUID = "not-own-submission-uuid";
-        postVote(randomID2, UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 499);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(randomID2, UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 499);
     });
 
-    it("should be able to completely downvote chapter using malicious", (done) => {
+    it("should be able to completely downvote chapter using malicious", async () => {
         const UUID = "chapter-uuid-1";
-        postVote(randomID2, UUID, 30)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, -2);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(randomID2, UUID, 30);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, -2);
     });
 
-    it("should not be able to completely downvote non-chapter using malicious", (done) => {
+    it("should not be able to completely downvote non-chapter using malicious", async () => {
         const UUID = "non-chapter-uuid-2";
-        postVote(randomID2, UUID, 30)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 0);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(randomID2, UUID, 30);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 0);
     });
 
-    it("Should be able to vote for a category and it should add your vote to the database", (done) => {
+    it("Should be able to vote for a category and it should add your vote to the database", async () => {
         const UUID = "vote-uuid-4";
-        postVoteCategory(randomID2, UUID, "intro")
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentCategory(UUID);
-                const categoryRows = await db.prepare("all", `SELECT votes, category FROM "categoryVotes" WHERE "UUID" = ?`, [UUID]);
-                assert.strictEqual(row.category, "sponsor");
-                assert.strictEqual(categoryRows.length, 2);
-                assert.strictEqual(categoryRows[0].votes, 1);
-                assert.strictEqual(categoryRows[0].category, "intro");
-                assert.strictEqual(categoryRows[1].votes, 1);
-                assert.strictEqual(categoryRows[1].category, "sponsor");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(randomID2, UUID, "intro");
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentCategory(UUID);
+        const categoryRows = await db.prepare("all", `SELECT votes, category FROM "categoryVotes" WHERE "UUID" = ?`, [UUID]);
+        assert.strictEqual(row.category, "sponsor");
+        assert.strictEqual(categoryRows.length, 2);
+        assert.strictEqual(categoryRows[0].votes, 1);
+        assert.strictEqual(categoryRows[0].category, "intro");
+        assert.strictEqual(categoryRows[1].votes, 1);
+        assert.strictEqual(categoryRows[1].category, "sponsor");
     });
 
-    it("Should not able to change to an invalid category", (done) => {
+    it("Should not able to change to an invalid category", async () => {
         const UUID = "incorrect-category";
-        postVoteCategory(randomID2, UUID, "fakecategory")
-            .then(async res => {
-                assert.strictEqual(res.status, 400);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, "sponsor");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(randomID2, UUID, "fakecategory");
+        assert.strictEqual(res.status, 400);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, "sponsor");
     });
 
-    it("Should not able to change to highlight category", (done) => {
+    it("Should not able to change to highlight category", async () => {
         const UUID = "incorrect-category";
-        postVoteCategory(randomID2, UUID, "highlight")
-            .then(async res => {
-                assert.strictEqual(res.status, 400);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, "sponsor");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(randomID2, UUID, "highlight");
+        assert.strictEqual(res.status, 400);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, "sponsor");
     });
 
-    it("Should not able to change to chapter category", (done) => {
+    it("Should not able to change to chapter category", async () => {
         const UUID = "incorrect-category";
-        postVoteCategory(randomID2, UUID, "chapter")
-            .then(async res => {
-                assert.strictEqual(res.status, 400);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, "sponsor");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(randomID2, UUID, "chapter");
+        assert.strictEqual(res.status, 400);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, "sponsor");
     });
 
-    it("Should be able to change your vote for a category and it should add your vote to the database(segment unlocked, nextCatgeory unlocked)", (done) => {
+    it("Should be able to change your vote for a category and it should add your vote to the database(segment unlocked, nextCatgeory unlocked)", async () => {
         const UUID = "vote-uuid-4";
-        postVoteCategory(randomID2, UUID, "outro")
-            .then(async res => {
-                assert.strictEqual(res.status, 200, "Status code should be 200");
-                const submissionRow = await getSegmentCategory(UUID);
-                const categoryRows = await db.prepare("all", `SELECT votes, category FROM "categoryVotes" WHERE "UUID" = ?`, [UUID]);
-                let introVotes = 0;
-                let outroVotes = 0;
-                let sponsorVotes = 0;
-                for (const row of categoryRows) {
-                    if (row?.category === "intro") introVotes += row?.votes;
-                    if (row?.category === "outro") outroVotes += row?.votes;
-                    if (row?.category === "sponsor") sponsorVotes += row?.votes;
-                }
-                assert.strictEqual(submissionRow.category, "sponsor");
-                assert.strictEqual(categoryRows.length, 3);
-                assert.strictEqual(introVotes, 0);
-                assert.strictEqual(outroVotes, 1);
-                assert.strictEqual(sponsorVotes, 1);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(randomID2, UUID, "outro");
+        assert.strictEqual(res.status, 200, "Status code should be 200");
+        const submissionRow = await getSegmentCategory(UUID);
+        const categoryRows = await db.prepare("all", `SELECT votes, category FROM "categoryVotes" WHERE "UUID" = ?`, [UUID]);
+        let introVotes = 0;
+        let outroVotes = 0;
+        let sponsorVotes = 0;
+        for (const row of categoryRows) {
+            if (row?.category === "intro") introVotes += row?.votes;
+            if (row?.category === "outro") outroVotes += row?.votes;
+            if (row?.category === "sponsor") sponsorVotes += row?.votes;
+        }
+        assert.strictEqual(submissionRow.category, "sponsor");
+        assert.strictEqual(categoryRows.length, 3);
+        assert.strictEqual(introVotes, 0);
+        assert.strictEqual(outroVotes, 1);
+        assert.strictEqual(sponsorVotes, 1);
     });
 
 
-    it("Should not be able to change your vote to an invalid category", (done) => {
+    it("Should not be able to change your vote to an invalid category", async () => {
         const UUID = "incorrect-category-change";
-        const vote = (inputCat: string, assertCat: string, callback: Mocha.Done) => {
-            postVoteCategory(randomID2, UUID, inputCat)
-                .then(async () => {
-                    const row = await getSegmentCategory(UUID);
-                    assert.strictEqual(row.category, assertCat);
-                    callback();
-                })
-                .catch(err => done(err));
+        const vote = async (inputCat: string, assertCat: string) => {
+            await postVoteCategory(randomID2, UUID, inputCat);
+            const row = await getSegmentCategory(UUID);
+            assert.strictEqual(row.category, assertCat);
         };
-        vote("sponsor", "sponsor", () => {
-            vote("fakeCategory", "sponsor", done);
-        });
+        await vote("sponsor", "sponsor");
+        await vote("fakeCategory", "sponsor");
     });
 
-    it("Submitter should be able to vote for a category and it should immediately change (segment unlocked, nextCatgeory unlocked, notVip)", (done) => {
+    it("Submitter should be able to vote for a category and it should immediately change (segment unlocked, nextCatgeory unlocked, notVip)", async () => {
         const userID = categoryChangeUser;
         const UUID = "category-change-uuid-1";
         const category = "sponsor";
-        postVoteCategory(userID, UUID, category)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, category);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(userID, UUID, category);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, category);
     });
 
-    it("Submitter's vote on the category should not work (segment locked, nextCatgeory unlocked, notVip)", (done) => {
+    it("Submitter's vote on the category should not work (segment locked, nextCatgeory unlocked, notVip)", async () => {
         const userID = categoryChangeUser;
         const UUID = "category-change-uuid-2";
         const category = "sponsor";
-        postVoteCategory(userID, UUID, category)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, "intro");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(userID, UUID, category);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, "intro");
     });
 
-    it("Submitter's vote on the category should not work (segment unlocked, nextCatgeory locked, notVip)", (done) => {
+    it("Submitter's vote on the category should not work (segment unlocked, nextCatgeory locked, notVip)", async () => {
         const userID = categoryChangeUser;
         const UUID = "category-change-uuid-3";
         const category = "preview";
-        postVoteCategory(userID, UUID, category)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, "intro");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(userID, UUID, category);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, "intro");
     });
 
-    it("Submitter's vote on the category should not work (segment locked, nextCatgeory locked, notVip)", (done) => {
+    it("Submitter's vote on the category should not work (segment locked, nextCatgeory locked, notVip)", async () => {
         const userID = categoryChangeUser;
         const UUID = "category-change-uuid-4";
         const category = "preview";
-        postVoteCategory(userID, UUID, category)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, "intro");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(userID, UUID, category);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, "intro");
     });
 
-    it("Vip should be able to vote for a category and it should immediately change (segment unlocked, nextCatgeory unlocked, Vip)", (done) => {
+    it("Vip should be able to vote for a category and it should immediately change (segment unlocked, nextCatgeory unlocked, Vip)", async () => {
         const userID = vipUser;
         const UUID = "category-change-uuid-5";
         const category = "sponsor";
-        postVoteCategory(userID, UUID, category)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, category);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(userID, UUID, category);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, category);
     });
 
-    it("Vip should be able to vote for a category and it should immediately change (segment locked, nextCatgeory unlocked, Vip)", (done) => {
+    it("Vip should be able to vote for a category and it should immediately change (segment locked, nextCatgeory unlocked, Vip)", async () => {
         const userID = vipUser;
         const UUID = "category-change-uuid-6";
         const category = "sponsor";
-        postVoteCategory(userID, UUID, category)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, category);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(userID, UUID, category);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, category);
     });
 
-    it("Vip should be able to vote for a category and it should immediately change (segment unlocked, nextCatgeory locked, Vip)", (done) => {
+    it("Vip should be able to vote for a category and it should immediately change (segment unlocked, nextCatgeory locked, Vip)", async () => {
         const userID = vipUser;
         const UUID = "category-change-uuid-7";
         const category = "preview";
-        postVoteCategory(userID, UUID, category)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, category);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(userID, UUID, category);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, category);
     });
 
-    it("Vip should be able to vote for a category and it should immediately change (segment locked, nextCatgeory locked, Vip)", (done) => {
+    it("Vip should be able to vote for a category and it should immediately change (segment locked, nextCatgeory locked, Vip)", async () => {
         const userID = vipUser;
         const UUID = "category-change-uuid-8";
         const category = "preview";
-        postVoteCategory(userID, UUID, category)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, category);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory(userID, UUID, category);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, category);
     });
 
-    it("Should not be able to vote for a category of a segment (Too many warning)", (done) => {
+    it("Should not be able to vote for a category of a segment (Too many warning)", async () => {
         const UUID = "category-warnvote-uuid-0";
         const category = "preview";
-        postVoteCategory("warn-voteuser01", UUID, category)
-            .then(res => {
-                assert.strictEqual(res.status, 403);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory("warn-voteuser01", UUID, category);
+        assert.strictEqual(res.status, 403);
     });
 
-    it("Should be able to vote for a category as a shadowbanned user, but it shouldn't add your vote to the database", (done) => {
+    it("Should be able to vote for a category as a shadowbanned user, but it shouldn't add your vote to the database", async () => {
         const UUID = "category-banvote-uuid-0";
         const category = "preview";
-        postVoteCategory("randomID4", UUID, category)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentCategory(UUID);
-                const categoryRows = await db.prepare("all", `SELECT votes, category FROM "categoryVotes" WHERE "UUID" = ?`, [UUID]);
-                assert.strictEqual(row.category, "intro");
-                assert.strictEqual(categoryRows.length, 0);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory("randomID4", UUID, category);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentCategory(UUID);
+        const categoryRows = await db.prepare("all", `SELECT votes, category FROM "categoryVotes" WHERE "UUID" = ?`, [UUID]);
+        assert.strictEqual(row.category, "intro");
+        assert.strictEqual(categoryRows.length, 0);
     });
 
-    it("Should not be able to category-vote on an invalid UUID submission", (done) => {
+    it("Should not be able to category-vote on an invalid UUID submission", async () => {
         const UUID = "invalid-uuid";
-        postVoteCategory("randomID3", UUID, "intro")
-            .then(res => {
-                assert.strictEqual(res.status, 404);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory("randomID3", UUID, "intro");
+        assert.strictEqual(res.status, 404);
     });
 
-    it("Should not be able to category-vote on a full video segment", (done) => {
+    it("Should not be able to category-vote on a full video segment", async () => {
         const UUID = "full-video-uuid-1";
-        postVoteCategory("randomID3", UUID, "selfpromo")
-            .then(res => {
-                assert.strictEqual(res.status, 400);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory("randomID3", UUID, "selfpromo");
+        assert.strictEqual(res.status, 400);
     });
 
-    it('Non-VIP should not be able to upvote "dead" submission', (done) => {
+    it('Non-VIP should not be able to upvote "dead" submission', async () => {
         const UUID = "vote-uuid-5";
-        postVote(randomID2, UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 403);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, -3);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(randomID2, UUID, 1);
+        assert.strictEqual(res.status, 403);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, -3);
     });
 
-    it('Non-VIP should not be able to downvote "dead" submission', (done) => {
+    it('Non-VIP should not be able to downvote "dead" submission', async () => {
         const UUID = "vote-uuid-5";
-        postVote(randomID2, UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, -3);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(randomID2, UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, -3);
     });
 
-    it('VIP should be able to upvote "dead" submission', (done) => {
+    it('VIP should be able to upvote "dead" submission', async () => {
         const UUID = "vote-uuid-5";
-        postVote(vipUser, UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.ok(row.votes > -3);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(vipUser, UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.ok(row.votes > -3);
     });
 
-    it("Should not be able to upvote a segment (Too many warning)", (done) => {
+    it("Should not be able to upvote a segment (Too many warning)", async () => {
         const UUID = "warnvote-uuid-0";
-        postVote("warn-voteuser01", UUID, 1)
-            .then(res => {
-                assert.strictEqual(res.status, 403);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote("warn-voteuser01", UUID, 1);
+        assert.strictEqual(res.status, 403);
     });
 
-    it("Non-VIP should not be able to downvote on a segment with no-segments category", (done) => {
+    it("Non-VIP should not be able to downvote on a segment with no-segments category", async () => {
         const UUID = "no-sponsor-segments-uuid-0";
-        postVote("randomID", UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 2);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote("randomID", UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 2);
     });
 
-    it("Non-VIP should be able to upvote on a segment with no-segments category", (done) => {
+    it("Non-VIP should be able to upvote on a segment with no-segments category", async () => {
         const UUID = "no-sponsor-segments-uuid-0";
-        postVote("randomID", UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 3);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote("randomID", UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 3);
     });
 
-    it("Non-VIP should not be able to category vote on a segment with no-segments category", (done) => {
+    it("Non-VIP should not be able to category vote on a segment with no-segments category", async () => {
         const UUID = "no-sponsor-segments-uuid-0";
-        postVoteCategory("randomID", UUID, "outro")
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentCategory(UUID);
-                assert.strictEqual(row.category, "sponsor");
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVoteCategory("randomID", UUID, "outro");
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentCategory(UUID);
+        assert.strictEqual(row.category, "sponsor");
     });
 
-    it("VIP upvote should lock segment", (done) => {
+    it("VIP upvote should lock segment", async () => {
         const UUID = "segment-locking-uuid-1";
-        postVote(vipUser, UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await db.prepare("get", `SELECT "locked" FROM "sponsorTimes" WHERE "UUID" = ?`, [UUID]);
-                assert.strictEqual(row.locked, 1);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(vipUser, UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const row = await db.prepare("get", `SELECT "locked" FROM "sponsorTimes" WHERE "UUID" = ?`, [UUID]);
+        assert.strictEqual(row.locked, 1);
     });
 
-    it("VIP downvote should unlock segment", (done) => {
+    it("VIP downvote should unlock segment", async () => {
         const UUID = "segment-locking-uuid-1";
-        postVote(vipUser, UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await db.prepare("get", `SELECT "locked" FROM "sponsorTimes" WHERE "UUID" = ?`, [UUID]);
-                assert.strictEqual(row.locked, 0);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(vipUser, UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await db.prepare("get", `SELECT "locked" FROM "sponsorTimes" WHERE "UUID" = ?`, [UUID]);
+        assert.strictEqual(row.locked, 0);
     });
 
-    it("VIP upvote should unhide segment", (done) => {
+    it("VIP upvote should unhide segment", async () => {
         const UUID = "segment-hidden-uuid-1";
-        postVote(vipUser, UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await db.prepare("get", `SELECT "hidden" FROM "sponsorTimes" WHERE "UUID" = ?`, [UUID]);
-                assert.strictEqual(row.hidden, 0);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(vipUser, UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const row = await db.prepare("get", `SELECT "hidden" FROM "sponsorTimes" WHERE "UUID" = ?`, [UUID]);
+        assert.strictEqual(row.hidden, 0);
     });
 
-    it("Should be able to undo-vote a segment", (done) => {
+    it("Should be able to undo-vote a segment", async () => {
         const UUID = "vote-uuid-2";
-        postVote(randomID2, UUID, 20)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 10);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(randomID2, UUID, 20);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 10);
     });
 
-    it("Should not be able to vote with type 10", (done) => {
+    it("Should not be able to vote with type 10", async () => {
         const UUID = "segment-locking-uuid-1";
-        postVote(vipUser, UUID, 10)
-            .then(res => {
-                assert.strictEqual(res.status, 400);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(vipUser, UUID, 10);
+        assert.strictEqual(res.status, 400);
     });
 
-    it("Should not be able to vote with type 11", (done) => {
+    it("Should not be able to vote with type 11", async () => {
         const UUID = "segment-locking-uuid-1";
-        postVote(vipUser, UUID, 11)
-            .then(res => {
-                assert.strictEqual(res.status, 400);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(vipUser, UUID, 11);
+        assert.strictEqual(res.status, 400);
     });
 
-    it("Should be able to update stored videoDuration with VIP upvote", (done) => {
+    it("Should be able to update stored videoDuration with VIP upvote", async () => {
         const UUID = "duration-update-uuid-1";
-        postVote(vipUser, UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const { videoDuration } = await db.prepare("get", `SELECT "videoDuration" FROM "sponsorTimes" WHERE "UUID" = ?`, [UUID]);
-                assert.strictEqual(videoDuration, 500);
-                done();
-            });
+        const res = await postVote(vipUser, UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const { videoDuration } = await db.prepare("get", `SELECT "videoDuration" FROM "sponsorTimes" WHERE "UUID" = ?`, [UUID]);
+        assert.strictEqual(videoDuration, 500);
     });
 
-    it("Should hide changed submission on any downvote", (done) => {
+    it("Should hide changed submission on any downvote", async () => {
         const UUID = "duration-changed-uuid-3";
         const videoID = "duration-changed";
-        postVote(randomID2, UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const hiddenSegments = await db.prepare("all", `SELECT "UUID" FROM "sponsorTimes" WHERE "videoID" = ? AND "hidden" = 1`, [videoID]);
-                assert.strictEqual(hiddenSegments.length, 2);
-                const expected = [{
-                    "UUID": "duration-changed-uuid-1",
-                }, {
-                    "UUID": "duration-changed-uuid-2",
-                }];
-                arrayDeepEquals(hiddenSegments, expected);
-                done();
-            });
+        const res = await postVote(randomID2, UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const hiddenSegments = await db.prepare("all", `SELECT "UUID" FROM "sponsorTimes" WHERE "videoID" = ? AND "hidden" = 1`, [videoID]);
+        assert.strictEqual(hiddenSegments.length, 2);
+        const expected = [{
+            "UUID": "duration-changed-uuid-1",
+        }, {
+            "UUID": "duration-changed-uuid-2",
+        }];
+        arrayDeepEquals(hiddenSegments, expected);
     });
 
-    it("Should be able to downvote segment with ajacent actionType lock", (done) => {
+    it("Should be able to downvote segment with ajacent actionType lock", async () => {
         const UUID = "no-sponsor-segments-uuid-2";
-        postVote(randomID2, UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 1);
-                done();
-            });
+        const res = await postVote(randomID2, UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 1);
     });
 
-    it("Should not be able to revive full video segment as non-vip", (done) => {
+    it("Should not be able to revive full video segment as non-vip", async () => {
         const UUID = "full-video-uuid-1";
-        postVote("VIPUser", UUID, 0).then(() => {
-            postVote("randomID3", UUID, 1)
-                .then(async res => {
-                    assert.strictEqual(res.status, 200);
-                    const row = await getSegmentVotes(UUID);
-                    assert.strictEqual(row.votes, -2);
-                    done();
-                })
-                .catch(err => done(err));
-        });
+        await postVote("VIPUser", UUID, 0);
+        const res = await postVote("randomID3", UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, -2);
     });
 
-    it("Should be able to upvote a segment if the user has submitted that in category", (done) => {
+    it("Should be able to upvote a segment if the user has submitted that in category", async () => {
         const UUID = "testing-outro-skip-1";
-        postVote(outroSubmitter, UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 1);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(outroSubmitter, UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 1);
     });
 
-    it("Should be able to downvote a segment if the user has submitted that in category", (done) => {
+    it("Should be able to downvote a segment if the user has submitted that in category", async () => {
         const UUID = "testing-outro-skip-2";
-        postVote(outroSubmitter, UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, -1);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(outroSubmitter, UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, -1);
     });
 
-    it("Should be able to upvote a segment if the user has submitted that in category but different action", (done) => {
+    it("Should be able to upvote a segment if the user has submitted that in category but different action", async () => {
         const UUID = "testing-outro-mute-1";
-        postVote(outroSubmitter, UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 1);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(outroSubmitter, UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 1);
     });
 
-    it("Should be able to downvote a segment if the user has submitted that in category but different action", (done) => {
+    it("Should be able to downvote a segment if the user has submitted that in category but different action", async () => {
         const UUID = "testing-outro-mute-2";
-        postVote(outroSubmitter, UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, -1);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(outroSubmitter, UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, -1);
     });
 
-    it("Should not be able to upvote a segment if the user's only submission of that category was downvoted", (done) => {
+    it("Should not be able to upvote a segment if the user's only submission of that category was downvoted", async () => {
         const UUID = "testing-intro-skip-1";
-        postVote(badIntroSubmitter, UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 0);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(badIntroSubmitter, UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 0);
     });
 
-    it("Should not be able to downvote a segment if the user's only submission of that category was downvoted", (done) => {
+    it("Should not be able to downvote a segment if the user's only submission of that category was downvoted", async () => {
         const UUID = "testing-intro-skip-2";
-        postVote(badIntroSubmitter, UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 0);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(badIntroSubmitter, UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 0);
     });
 
-    it("Should not be able to upvote a segment if the user's only submission of that category was hidden", (done) => {
+    it("Should not be able to upvote a segment if the user's only submission of that category was hidden", async () => {
         const UUID = "testing-interaction-skip-1";
-        postVote(hiddenInteractionSubmitter, UUID, 1)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 0);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(hiddenInteractionSubmitter, UUID, 1);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 0);
     });
 
-    it("Should not be able to downvote a segment if the user's only submission of that category was hidden", (done) => {
+    it("Should not be able to downvote a segment if the user's only submission of that category was hidden", async () => {
         const UUID = "testing-interaction-skip-2";
-        postVote(hiddenInteractionSubmitter, UUID, 0)
-            .then(async res => {
-                assert.strictEqual(res.status, 200);
-                const row = await getSegmentVotes(UUID);
-                assert.strictEqual(row.votes, 0);
-                done();
-            })
-            .catch(err => done(err));
+        const res = await postVote(hiddenInteractionSubmitter, UUID, 0);
+        assert.strictEqual(res.status, 200);
+        const row = await getSegmentVotes(UUID);
+        assert.strictEqual(row.votes, 0);
     });
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -59,12 +59,13 @@ async function init() {
             mocha.run((failures) => {
                 mockServer.close();
                 server.close();
-                redis.quit();
-                process.exitCode = failures ? 1 : 0; // exit with non-zero status if there were failures
-                process.exit();
+                redis.quit().finally(() => {
+                    process.exitCode = failures ? 1 : 0; // exit with non-zero status if there were failures
+                    process.exit();
+                });
             });
         });
     });
 }
 
-init();
+void init();

--- a/test/utils/randomUsers.ts
+++ b/test/utils/randomUsers.ts
@@ -1,0 +1,51 @@
+import { HashedUserID, UserID } from "../../src/types/user.model";
+import { getHash } from "../../src/utils/getHash";
+import { genRandom } from "./getRandom";
+
+export interface TestUser {
+    private: UserID,
+    public: HashedUserID,
+}
+
+interface InternalTestUsers {
+    map: Map<any, TestUser>,
+    suiteName: string,
+}
+
+const userMapHandler = {
+    get(target: InternalTestUsers, property: string): TestUser {
+        const suiteName = Reflect.get(target, "suiteName");
+        const map = Reflect.get(target, "map");
+        let user = map.get(property);
+        if (user !== undefined) {
+            return user;
+        }
+
+        const priv = `${suiteName}-${property}-${genRandom}` as UserID;
+        user = {
+            private: priv,
+            public: getHash(priv),
+        };
+        map.set(property, user);
+        return user;
+    },
+    set: () => false, // nope
+    deleteProperty: () => false, // nope
+    has: () => true, // yep
+    defineProperty: () => false, // nope
+    preventExtensions: () => false, // nope
+    setPrototypeOf: () => false, // nope
+};
+
+/**
+ * Creates an object that generates test private/public userID pairs on demand
+ *
+ * @param suiteName the suite name, used as a prefix for the private userID
+ * @returns a proxy that generates & caches private/public userID pairs for each property access
+ */
+export function usersForSuite(suiteName: string): Record<any, TestUser> {
+    return new Proxy({
+        map: new Map<any, TestUser>(),
+        suiteName,
+    }, userMapHandler) as unknown as Record<any, TestUser>;
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["**/*"],
+}


### PR DESCRIPTION
- [x] I agree to license my contribution under AGPL-3.0-only with my contribution automatically being licensed under LGPL-3.0 additionally after 6 months

***
this pr:
- adds additional typing for `IDatabase::prepare` based on overloads, making TS able to infer the correct return type based on stated query type (though the only options are `any`, `any[]` and `void`)
- removes the unused warning expiry and max warning count config settings
- makes `routes/postWarning.ts` not overwrite previous warnings when a user is warned again
- prevents `routes/postWarning.ts` from inserting a second warning if a user already has a warning (even if by a different VIP user)
  - exception: the VIP that issued the warning has 15 minutes to edit the reason by submitting the warning again (no unwarn required)
- adds a new `disableTime` nullable column that is set when a warning is disabled
- adjusts and adds new test cases for changed behaviour
  - also adds the `usersForSuite` utility which generates a proxy pseudo-object that allows for easy generation of public/private userID pairs for each test case
- also fixes a bunch of test case hooks that didn't await `db.prepare` calls after postgres tests failed on this pr
- makes eslint check tests with typescript lints too, not just js lints (mainly promise lints)
- fixes all uncovered eslint issues
- rewrites a bunch of tests from callback style to promise style
  - as the issues uncovered by eslint lints have shown, it's way too easy to forget about a .catch() clause
  - the test would likely timeout on failure, but you wouldn't get a proper error
  - plus promise style saves 4 lines per test case c: