### PR TITLE
set default minVotes param in search segments to -Infinity

### DIFF
--- a/src/routes/getSearchSegments.ts
+++ b/src/routes/getSearchSegments.ts
@@ -94,7 +94,7 @@ async function handleGetSegments(req: Request, res: Response): Promise<searchSeg
     const sortBy: SortableFields = getSortField(req.query.sortBy, req.body.sortBy);
     const sortDir: string = req.query.sortDir ?? req.body.sortDir ?? "asc";
 
-    const minVotes: number = req.query.minVotes ?? req.body.minVotes ?? -3;
+    const minVotes: number = req.query.minVotes ?? req.body.minVotes ?? -Infinity;
     const maxVotes: number = req.query.maxVotes ?? req.body.maxVotes ?? Infinity;
 
     const minViews: number = req.query.minViews ?? req.body.minViews ?? -1;


### PR DESCRIPTION
- [x] I agree to license my contribution under AGPL-3.0-only with my contribution automatically being licensed under LGPL-3.0 additionally after 6 months

***

it would be very nice to assume our database would be consistent with the intended behaviour, but alas it is not, and it is still possible to double-downvote a segment if the server is sufficiently laggy.

the minVotes param defaulting to -3 was a source of confusion in VIPs multiple times already, where they thought a segment had completely disappeared from the db, but it was simply excluded from the results due to being below the default vote threshold to return. search segments is expected to return all submitted segments on a video if no parameters are set.